### PR TITLE
[Fix] Fix double capacity check for granaries carts

### DIFF
--- a/src/building/granary.c
+++ b/src/building/granary.c
@@ -167,7 +167,7 @@ int building_granary_remove_for_getting_deliveryman(building *src, building *dst
         }
     }
     
-    if ((CONFIG_GP_CH_GRANARIES_GET_DOUBLE)) {
+    if (config_get(CONFIG_GP_CH_GRANARIES_GET_DOUBLE)) {
         if (max_amount > 1600) {
             max_amount = 1600;
         }


### PR DESCRIPTION
This option has only a graphic effect, but the cart capacity always increases.