### PR TITLE
No mine/pit collapsing if city has no mines/pits

### DIFF
--- a/src/building/building.c
+++ b/src/building/building.c
@@ -36,6 +36,17 @@ building *building_get(int id)
     return &all_buildings[id];
 }
 
+int building_find(building_type type)
+{
+    for (int i = 0; i < MAX_BUILDINGS; ++i) {
+        building *b = building_get(i);
+        if (b->state == BUILDING_STATE_IN_USE && b->type == type) {
+            return i;
+        }
+    }
+    return MAX_BUILDINGS;
+}
+
 building *building_main(building *b)
 {
     for (int guard = 0; guard < 9; guard++) {

--- a/src/building/building.h
+++ b/src/building/building.h
@@ -144,6 +144,8 @@ typedef struct {
 
 building *building_get(int id);
 
+int building_find(building_type type);
+
 building *building_main(building *b);
 
 building *building_next(building *b);

--- a/src/building/destruction.c
+++ b/src/building/destruction.c
@@ -149,17 +149,16 @@ void building_destroy_by_rioter(building *b)
 
 int building_destroy_first_of_type(building_type type)
 {
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
-        building *b = building_get(i);
-        if (b->state == BUILDING_STATE_IN_USE && b->type == type) {
-            int grid_offset = b->grid_offset;
-            game_undo_disable();
-            b->state = BUILDING_STATE_RUBBLE;
-            map_building_tiles_set_rubble(i, b->x, b->y, b->size);
-            sound_effect_play(SOUND_EFFECT_EXPLOSION);
-            map_routing_update_land();
-            return grid_offset;
-        }
+    int i = building_find(type);
+    if (i < MAX_BUILDINGS) {
+        building* b = building_get(i);
+        int grid_offset = b->grid_offset;
+        game_undo_disable();
+        b->state = BUILDING_STATE_RUBBLE;
+        map_building_tiles_set_rubble(i, b->x, b->y, b->size);
+        sound_effect_play(SOUND_EFFECT_EXPLOSION);
+        map_routing_update_land();
+        return grid_offset;
     }
     return 0;
 }

--- a/src/scenario/random_event.c
+++ b/src/scenario/random_event.c
@@ -98,9 +98,11 @@ static void destroy_iron_mine(void)
 {
     if (scenario.random_events.iron_mine_collapse) {
         if(config_get(CONFIG_GP_CH_RANDOM_COLLAPSES_TAKE_MONEY)) {
-            city_finance_process_sundry(250);
-            city_message_post(1, MESSAGE_IRON_MINE_COLLAPED, 0, 0);
-	} else {
+            if(building_find(BUILDING_IRON_MINE) < MAX_BUILDINGS) {
+                city_finance_process_sundry(250);
+                city_message_post(1, MESSAGE_IRON_MINE_COLLAPED, 0, 0);
+            }
+    } else {
             int grid_offset = building_destroy_first_of_type(BUILDING_IRON_MINE);
             if (grid_offset) {
                 city_message_post(1, MESSAGE_IRON_MINE_COLLAPED, 0, grid_offset);
@@ -113,9 +115,11 @@ static void destroy_clay_pit(void)
 {
     if (scenario.random_events.clay_pit_flooded) {
         if(config_get(CONFIG_GP_CH_RANDOM_COLLAPSES_TAKE_MONEY)) {
-            city_finance_process_sundry(250);
-            city_message_post(1, MESSAGE_CLAY_PIT_FLOODED, 0, 0);
-	} else {	    
+            if(building_find(BUILDING_CLAY_PIT) < MAX_BUILDINGS) {
+                city_finance_process_sundry(250);
+                city_message_post(1, MESSAGE_CLAY_PIT_FLOODED, 0, 0);
+            }
+        } else {
             int grid_offset = building_destroy_first_of_type(BUILDING_CLAY_PIT);
             if (grid_offset) {
                 city_message_post(1, MESSAGE_CLAY_PIT_FLOODED, 0, grid_offset);


### PR DESCRIPTION
In the case of the CONFIG_GP_CH_RANDOM_COLLAPSES_TAKE_MONEY options, mines and pits could collaps in a city without mines/pits. Fixes this bug.