### PR TITLE
Show more info on senate and number of unemployed people in chief advisor window

### DIFF
--- a/src/graphics/tooltip.c
+++ b/src/graphics/tooltip.c
@@ -11,6 +11,8 @@
 #include "graphics/screen.h"
 #include "graphics/text.h"
 #include "graphics/window.h"
+#include "scenario/criteria.h"
+#include "scenario/property.h"
 #include "window/advisors.h"
 
 #include <stdlib.h>
@@ -215,7 +217,7 @@ static void draw_overlay_tooltip(tooltip_context *c)
 static void draw_senate_tooltip(tooltip_context *c)
 {
     int x, y;
-    int width = 180;
+    int width = 220;
     int height = 80;
     if (c->mouse_x < width + 20) {
         x = c->mouse_x + 20;
@@ -237,25 +239,43 @@ static void draw_senate_tooltip(tooltip_context *c)
 
     // unemployment
     lang_text_draw_colored(68, 148, x + 5, y + 5, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
-    text_draw_number_colored(city_labor_unemployment_percentage(), '@', "%",
+    width = text_draw_number_colored(city_labor_unemployment_percentage(), '@', "%",
         x + 140, y + 5, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
+    text_draw_number_colored(city_labor_workers_unemployed() - city_labor_workers_needed(), '(', ")",
+        x + 140 + width, y + 5, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
 
     // ratings
     lang_text_draw_colored(68, 149, x + 5, y + 19, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
     text_draw_number_colored(city_rating_culture(), '@', " ",
         x + 140, y + 19, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
+    if ( !scenario_is_open_play() && scenario_criteria_culture_enabled()) {
+        text_draw_number_colored(scenario_criteria_culture(), '(', ")",
+            x + 140 + width, y + 19, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
+    }
 
     lang_text_draw_colored(68, 150, x + 5, y + 33, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
     text_draw_number_colored(city_rating_prosperity(), '@', " ",
         x + 140, y + 33, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
+    if ( !scenario_is_open_play() && scenario_criteria_prosperity_enabled()) {
+        text_draw_number_colored(scenario_criteria_prosperity(), '(', ")",
+            x + 140 + width, y + 33, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
+    }
 
     lang_text_draw_colored(68, 151, x + 5, y + 47, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
     text_draw_number_colored(city_rating_peace(), '@', " ",
         x + 140, y + 47, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
+    if ( !scenario_is_open_play() && scenario_criteria_peace_enabled()) {
+        text_draw_number_colored(scenario_criteria_peace(), '(', ")",
+            x + 140 + width, y + 47, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
+    }
 
     lang_text_draw_colored(68, 152, x + 5, y + 61, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
     text_draw_number_colored(city_rating_favor(), '@', " ",
         x + 140, y + 61, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
+    if ( !scenario_is_open_play() && scenario_criteria_favor_enabled()) {
+        text_draw_number_colored(scenario_criteria_favor(), '(', ")",
+            x + 140 + width, y + 61, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
+    }
 }
 
 static void draw_tooltip(tooltip_context *c)

--- a/src/window/advisor/chief.c
+++ b/src/window/advisor/chief.c
@@ -40,7 +40,8 @@ static int draw_background(void)
     draw_title(66, 1);
     if (city_labor_unemployment_percentage() > 0) {
         width = lang_text_draw(61, 12, X_OFFSET, 66, FONT_NORMAL_RED);
-        text_draw_percentage(city_labor_unemployment_percentage(), X_OFFSET + width, 66, FONT_NORMAL_RED);
+        width += text_draw_percentage(city_labor_unemployment_percentage(), X_OFFSET + width, 66, FONT_NORMAL_RED);
+        text_draw_number(city_labor_workers_unemployed() - city_labor_workers_needed(), '(', ")", X_OFFSET + 11 + width, 66, FONT_NORMAL_RED);
     } else if (city_labor_workers_needed() > 0) {
         width = lang_text_draw(61, 13, X_OFFSET, 66, FONT_NORMAL_RED);
         lang_text_draw_amount(8, 12, city_labor_workers_needed(), X_OFFSET + width, 66, FONT_NORMAL_RED);


### PR DESCRIPTION
To align the senate and chief advisor with the new info panel, I added the number of unemployed people in the senate tooltip and in the chief advisor window.
I also added the goal for the ratings in the senate tooltip. I decided to not show them if the map is freebuild, instead of showing "(0)", like the extra info panel, but this can be changed easily if you think it looks better with the 0 instead of empty space.

![advisor](https://user-images.githubusercontent.com/4594052/86161077-06b95680-bb0d-11ea-979b-ed60f517694b.png)
![senate](https://user-images.githubusercontent.com/4594052/86161092-091bb080-bb0d-11ea-88c1-996357bba975.png)
