### PR TITLE
Warehouses delivering to each other

### DIFF
--- a/src/figuretype/cartpusher.c
+++ b/src/figuretype/cartpusher.c
@@ -3,6 +3,7 @@
 #include "building/barracks.h"
 #include "building/granary.h"
 #include "building/industry.h"
+#include "building/storage.h"
 #include "building/warehouse.h"
 #include "city/resource.h"
 #include "core/calc.h"
@@ -424,7 +425,9 @@ static void determine_warehouseman_destination(figure *f, int road_network_id)
     // priority 5: resource to other warehouse
     dst_building_id = building_warehouse_for_storing(f->building_id, f->x, f->y, f->resource_id,
         warehouse->distance_from_entry, road_network_id, 0, &dst);
-    if (dst_building_id) {
+    
+    int empty_warehouse = building_storage_get(building_get(f->building_id)->storage_id)->empty_all; // deliver to another warehouse because this one is being emptied
+    if (dst_building_id && empty_warehouse) {
         if (dst_building_id == f->building_id) {
             f->state = FIGURE_STATE_DEAD;
         } else {


### PR DESCRIPTION
![warehouse bug](https://user-images.githubusercontent.com/4594052/86507664-4cf70a00-bdda-11ea-8e5f-d0f9d5b0c12d.PNG)

When there are two warehouses accepting a raw material resource and a disconnected industry (like in the picture), the two warehouses will deliver the raw resource to each other endlessly (both warehouses are just set to accept wood). This also happens in C3 base game so I'm creating the pull request here instead of julius.

Note that with this fix, the warehouse figure will still spawn and disappear after 2 ticks due to the delay in "figure_warehouseman_action" between creating the figure and calculating a task for it (example in #52), but at least it won't travel to another warehouse without reason.