### PR TITLE
Console and custom commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -509,6 +509,7 @@ set(WINDOW_FILES
     ${PROJECT_SOURCE_DIR}/src/window/cck_selection.c
     ${PROJECT_SOURCE_DIR}/src/window/city.c
     ${PROJECT_SOURCE_DIR}/src/window/config.c
+    ${PROJECT_SOURCE_DIR}/src/window/console.c
     ${PROJECT_SOURCE_DIR}/src/window/difficulty_options.c
     ${PROJECT_SOURCE_DIR}/src/window/display_options.c
     ${PROJECT_SOURCE_DIR}/src/window/donate_to_city.c

--- a/src/city/emperor.c
+++ b/src/city/emperor.c
@@ -13,6 +13,8 @@
 
 const int SALARY_FOR_RANK[11] = {0, 2, 5, 8, 12, 20, 30, 40, 60, 80, 100};
 
+static int cheated_invasion = 0;
+
 void city_emperor_init_scenario(int rank)
 {
     city_data.ratings.favor = scenario_starting_favor();
@@ -87,7 +89,7 @@ static void update_debt_state(void)
 
 static void process_caesar_invasion(void)
 {
-    if (city_data.figure.imperial_soldiers) {
+    if (city_data.figure.imperial_soldiers && !cheated_invasion) {
         // caesar invasion in progress
         city_data.emperor.invasion.duration_day_countdown--;
         if (city_data.ratings.favor >= 35 && city_data.emperor.invasion.duration_day_countdown < 176) {
@@ -141,6 +143,7 @@ static void process_caesar_invasion(void)
                 size = 144;
             }
             if (scenario_invasion_start_from_caesar(size)) {
+                cheated_invasion = 0;
                 city_data.emperor.invasion.count++;
                 city_data.emperor.invasion.duration_day_countdown = 192;
                 city_data.emperor.invasion.retreat_message_shown = 0;
@@ -328,4 +331,16 @@ int city_emperor_donate_amount(void)
 void city_emperor_mark_soldier_killed(void)
 {
     city_data.emperor.invasion.soldiers_killed++;
+}
+
+void city_emperor_force_attack(int size){
+    if (scenario_invasion_start_from_caesar(size)) {
+        cheated_invasion = 1;
+        city_data.emperor.invasion.count++;
+        city_data.emperor.invasion.days_until_invasion = 0;
+        city_data.emperor.invasion.duration_day_countdown = 192;
+        city_data.emperor.invasion.retreat_message_shown = 0;
+        city_data.emperor.invasion.size = size;
+        city_data.emperor.invasion.soldiers_killed = 0;
+    }
 }

--- a/src/city/emperor.h
+++ b/src/city/emperor.h
@@ -51,4 +51,6 @@ int city_emperor_rank(void);
 
 void city_emperor_mark_soldier_killed(void);
 
+void city_emperor_force_attack(int size);
+
 #endif // CITY_EMPEROR_H

--- a/src/city/finance.c
+++ b/src/city/finance.c
@@ -68,6 +68,12 @@ void city_finance_process_cheat(void)
     }
 }
 
+void city_finance_process_console(int amount)
+{
+    city_data.finance.treasury += amount;
+    city_data.finance.cheated_money += amount;
+}
+
 void city_finance_process_stolen(int stolen)
 {
     city_data.finance.stolen_this_year += stolen;

--- a/src/city/finance.h
+++ b/src/city/finance.h
@@ -21,6 +21,8 @@ void city_finance_process_export(int price);
 
 void city_finance_process_cheat(void);
 
+void city_finance_process_console(int amount);
+
 void city_finance_process_stolen(int stolen);
 
 void city_finance_process_donation(int amount);

--- a/src/city/gods.c
+++ b/src/city/gods.c
@@ -398,3 +398,7 @@ int city_god_neptune_create_shipwreck_flotsam(void)
         return 0;
     }
 }
+
+void city_god_blessing_cheat(int god_id){
+    perform_blessing(god_id);
+}

--- a/src/city/gods.h
+++ b/src/city/gods.h
@@ -26,4 +26,6 @@ void city_god_spirit_of_mars_mark_used(void);
 
 int city_god_neptune_create_shipwreck_flotsam(void);
 
+void city_god_blessing_cheat(int god_id);
+
 #endif // CITY_GODS_H

--- a/src/city/warning.c
+++ b/src/city/warning.c
@@ -83,3 +83,13 @@ void city_warning_clear_outdated(void)
         }
     }
 }
+
+void city_warning_show_console(uint8_t* warning_text){
+    struct warning *w = new_warning();
+    if (!w) {
+        return;
+    }
+    w->in_use = 1;
+    w->time = time_get_millis();
+    string_copy(warning_text, w->text, MAX_TEXT);
+}

--- a/src/city/warning.h
+++ b/src/city/warning.h
@@ -68,4 +68,6 @@ const uint8_t *city_warning_get(int id);
 void city_warning_clear_all(void);
 void city_warning_clear_outdated(void);
 
+void city_warning_show_console(uint8_t * warning_text);
+
 #endif // CITY_WARNING_H

--- a/src/game/cheats.c
+++ b/src/game/cheats.c
@@ -2,26 +2,34 @@
 
 #include "building/construction.h"
 #include "building/type.h"
+#include "city/gods.h"
 #include "city/finance.h"
 #include "city/victory.h"
 #include "city/warning.h"
 #include "core/string.h"
+#include "game/tick.h"
 #include "graphics/window.h"
 #include "scenario/invasion.h"
 #include "window/building_info.h"
 #include "window/city.h"
 #include "window/console.h"
 
-#define NUMBER_OF_COMMANDS 1
+#define NUMBER_OF_COMMANDS 3
 
 static void game_cheat_add_money(uint8_t *);
+static void game_cheat_advance_year(uint8_t *);
+static void game_cheat_cast_blessing(uint8_t *);
 
 static void (* const execute_command[])(uint8_t * args) = {
     game_cheat_add_money,
+    game_cheat_advance_year,
+    game_cheat_cast_blessing,
 };
 
 static const char *commands[] = {
     "addmoney",
+    "nextyear",
+    "blessing",
 };
 
 static struct {
@@ -101,6 +109,20 @@ static void game_cheat_add_money(uint8_t * args){
     window_invalidate();
 
     city_warning_show_console((uint8_t*)"Added money");
+}
+
+static void game_cheat_advance_year(uint8_t * args){
+    game_tick_cheat_year();
+
+    city_warning_show_console((uint8_t*)"Year advanced");
+} 
+
+static void game_cheat_cast_blessing(uint8_t * args){
+    int god_id = 0;
+    parse_integer(args, &god_id);
+    city_god_blessing_cheat(god_id);
+
+    city_warning_show_console((uint8_t*)"Casted blessing");
 }
 void game_cheat_parse_command(uint8_t * command){
     uint8_t command_to_call[MAX_COMMAND_SIZE];

--- a/src/game/cheats.c
+++ b/src/game/cheats.c
@@ -8,32 +8,42 @@
 #include "city/warning.h"
 #include "core/string.h"
 #include "game/tick.h"
+#include "graphics/color.h"
+#include "graphics/font.h"
+#include "graphics/text.h"
 #include "graphics/window.h"
 #include "scenario/invasion.h"
 #include "window/building_info.h"
 #include "window/city.h"
 #include "window/console.h"
 
-#define NUMBER_OF_COMMANDS 3
+#define NUMBER_OF_COMMANDS 5
 
 static void game_cheat_add_money(uint8_t *);
+static void game_cheat_start_invasion(uint8_t *);
 static void game_cheat_advance_year(uint8_t *);
 static void game_cheat_cast_blessing(uint8_t *);
+static void game_cheat_show_tooltip(uint8_t *);
 
 static void (* const execute_command[])(uint8_t * args) = {
     game_cheat_add_money,
+    game_cheat_start_invasion,
     game_cheat_advance_year,
     game_cheat_cast_blessing,
+    game_cheat_show_tooltip
 };
 
 static const char *commands[] = {
     "addmoney",
+    "startinvasion",
     "nextyear",
     "blessing",
+    "showtooltip"
 };
 
 static struct {
     int is_cheating;
+    int tooltip_enabled;
 } data;
 
 static int parse_word(uint8_t * string, uint8_t * word){
@@ -71,6 +81,10 @@ void game_cheat_activate(void)
     } else {
         data.is_cheating = 0;
     }
+}
+
+int game_cheat_tooltip_enabled(void){
+    return data.tooltip_enabled; 
 }
 
 void game_cheat_money(void)
@@ -111,6 +125,18 @@ static void game_cheat_add_money(uint8_t * args){
     city_warning_show_console((uint8_t*)"Added money");
 }
 
+static void game_cheat_start_invasion(uint8_t * args){
+    int attack_type = 0;
+    int size = 0;
+    int invasion_point = 0;
+    int index = parse_integer(args, &attack_type); // 0 barbarians, 1 caesar, 2 mars natives
+    index = parse_integer(args+index, &size);
+    parse_integer(args+index,&invasion_point);
+    scenario_invasion_start_from_console(attack_type, size, invasion_point);
+
+    city_warning_show_console((uint8_t*)"Started invasion");
+}
+
 static void game_cheat_advance_year(uint8_t * args){
     game_tick_cheat_year();
 
@@ -124,6 +150,15 @@ static void game_cheat_cast_blessing(uint8_t * args){
 
     city_warning_show_console((uint8_t*)"Casted blessing");
 }
+
+static void game_cheat_show_tooltip(uint8_t * args){
+    parse_integer(args, &data.tooltip_enabled);
+
+    city_warning_show_console((uint8_t*)"Show tooltip toggled");
+
+}
+
+
 void game_cheat_parse_command(uint8_t * command){
     uint8_t command_to_call[MAX_COMMAND_SIZE];
     int next_arg = parse_word(command,command_to_call);

--- a/src/game/cheats.c
+++ b/src/game/cheats.c
@@ -1,16 +1,58 @@
 #include "cheats.h"
 
+#include "building/construction.h"
 #include "building/type.h"
 #include "city/finance.h"
 #include "city/victory.h"
+#include "city/warning.h"
+#include "core/string.h"
 #include "graphics/window.h"
 #include "scenario/invasion.h"
 #include "window/building_info.h"
+#include "window/city.h"
+#include "window/console.h"
+
+#define NUMBER_OF_COMMANDS 1
+
+static void game_cheat_add_money(uint8_t *);
+
+static void (* const execute_command[])(uint8_t * args) = {
+    game_cheat_add_money,
+};
+
+static const char *commands[] = {
+    "addmoney",
+};
 
 static struct {
     int is_cheating;
 } data;
 
+static int parse_word(uint8_t * string, uint8_t * word){
+    int count = 0;
+    while( *string && *string != ' '){
+        *word = *string;
+        word++;
+        string++;
+        count++;
+    }
+    *word = 0;
+    return count+1;
+}
+
+// return value is next argument index
+static int parse_integer(uint8_t * string, int * value){
+    uint8_t copy[MAX_COMMAND_SIZE];
+    int count = 0;
+    while( *string && *string != ' '){
+        copy[count] = *string;
+        count++;
+        string++;
+    }
+    copy[count] = 0;
+    *value = string_to_int(copy);
+    return count+1;
+}
 void game_cheat_activate(void)
 {
     if (window_is(WINDOW_BUILDING_INFO)) {
@@ -35,5 +77,37 @@ void game_cheat_victory(void)
 {
     if (data.is_cheating) {
         city_victory_force_win();
+    }
+}
+
+void game_cheat_breakpoint(){
+    if (data.is_cheating) {
+        asm("nop");
+    }
+}
+
+void game_cheat_console(){
+    if (data.is_cheating) {
+        building_construction_clear_type();
+        window_city_show();
+        window_console_show();
+    }
+}
+
+static void game_cheat_add_money(uint8_t * args){
+    int money = 0;
+    parse_integer(args, &money);
+    city_finance_process_console(money);
+    window_invalidate();
+
+    city_warning_show_console((uint8_t*)"Added money");
+}
+void game_cheat_parse_command(uint8_t * command){
+    uint8_t command_to_call[MAX_COMMAND_SIZE];
+    int next_arg = parse_word(command,command_to_call);
+    for (int i = 0; i < NUMBER_OF_COMMANDS; i++) {
+        if (string_compare_case_insensitive((char *)command_to_call, commands[i]) == 0) {
+            (*execute_command[i])(command+next_arg);
+        }
     }
 }

--- a/src/game/cheats.h
+++ b/src/game/cheats.h
@@ -7,6 +7,8 @@
 
 void game_cheat_activate(void);
 
+int game_cheat_tooltip_enabled(void);
+
 void game_cheat_money(void);
 
 void game_cheat_victory(void);

--- a/src/game/cheats.h
+++ b/src/game/cheats.h
@@ -1,10 +1,23 @@
 #ifndef GAME_CHEATS_H
 #define GAME_CHEATS_H
 
+#include <stdint.h>
+
+#define MAX_COMMAND_SIZE 64
+
 void game_cheat_activate(void);
 
 void game_cheat_money(void);
 
 void game_cheat_victory(void);
+
+/**
+ * Does nothing, just set breakpoint in implementation and call it with alt + b
+ */
+void game_cheat_breakpoint(void);
+
+void game_cheat_console(void);
+
+void game_cheat_parse_command(uint8_t * command);
 
 #endif // GAME_CHEATS_H

--- a/src/game/tick.c
+++ b/src/game/tick.c
@@ -181,3 +181,7 @@ void game_tick_run(void)
     scenario_emperor_change_process();
     city_victory_check();
 }
+
+void game_tick_cheat_year(void){
+    advance_year();
+}

--- a/src/game/tick.h
+++ b/src/game/tick.h
@@ -3,4 +3,6 @@
 
 void game_tick_run(void);
 
+void game_tick_cheat_year(void);
+
 #endif // GAME_TICK_H

--- a/src/graphics/tooltip.h
+++ b/src/graphics/tooltip.h
@@ -9,7 +9,8 @@ typedef enum {
     TOOLTIP_NONE = 0,
     TOOLTIP_BUTTON = 1,
     TOOLTIP_OVERLAY = 2,
-    TOOLTIP_SENATE = 3
+    TOOLTIP_SENATE = 3,
+    TOOLTIP_TILES = 4
 } tooltip_type;
 
 typedef struct {

--- a/src/platform/keyboard_input.c
+++ b/src/platform/keyboard_input.c
@@ -281,6 +281,11 @@ void platform_handle_key_down(SDL_KeyboardEvent *event)
             case SDLK_v:
                 game_cheat_victory();
                 break;
+            case SDLK_b:
+                game_cheat_breakpoint();
+                break;
+            case SDLK_x:
+                game_cheat_console();
         }
     }
 }

--- a/src/scenario/invasion.c
+++ b/src/scenario/invasion.c
@@ -1,6 +1,7 @@
 #include "invasion.h"
 
 #include "building/destruction.h"
+#include "city/emperor.h"
 #include "city/message.h"
 #include "core/calc.h"
 #include "core/random.h"
@@ -66,6 +67,12 @@ static const struct {
     {80, 20, 0, {FIGURE_ENEMY44_SWORD, FIGURE_ENEMY46_CAMEL, 0}, FORMATION_ENEMY_WIDE_COLUMN}, // egyptian
     {90, 10, 0, {FIGURE_ENEMY45_SWORD, FIGURE_ENEMY47_ELEPHANT, 0}, FORMATION_ENEMY_WIDE_COLUMN}, // carthaginian
     {100, 0, 0, {FIGURE_ENEMY_CAESAR_LEGIONARY, 0, 0}, FORMATION_COLUMN} // caesar
+};
+
+enum {
+    ATTACK_TYPE_BARBARIAN,
+    ATTACK_TYPE_CAESAR,
+    ATTACK_TYPE_NATIVES
 };
 
 typedef struct {
@@ -432,6 +439,41 @@ void scenario_invasion_start_from_cheat(void)
         } else {
             city_message_post(1, MESSAGE_BARBARIAN_ATTACK, data.last_internal_invasion_id, grid_offset);
         }
+    }
+}
+
+void scenario_invasion_start_from_console(int attack_type, int size, int invasion_point)
+{
+    switch(attack_type){
+
+        case ATTACK_TYPE_BARBARIAN:
+        {
+            int enemy_id = scenario.enemy_id;
+            int grid_offset = start_invasion(ENEMY_ID_TO_ENEMY_TYPE[enemy_id], size, invasion_point, FORMATION_ATTACK_RANDOM, 23);
+            if (grid_offset) {
+                if (ENEMY_ID_TO_ENEMY_TYPE[enemy_id] > 4) {
+                    city_message_post(1, MESSAGE_ENEMY_ARMY_ATTACK, data.last_internal_invasion_id, grid_offset);
+                } else {
+                    city_message_post(1, MESSAGE_BARBARIAN_ATTACK, data.last_internal_invasion_id, grid_offset);
+                }
+            }
+            break;
+        }
+        case ATTACK_TYPE_CAESAR:
+        {
+            city_emperor_force_attack(size);
+            break;
+        }
+        case ATTACK_TYPE_NATIVES:
+        {
+            int grid_offset = start_invasion(ENEMY_0_BARBARIAN, size, 8, FORMATION_ATTACK_FOOD_CHAIN, 23);
+            if (grid_offset) {
+                city_message_post(1, MESSAGE_LOCAL_UPRISING_MARS, data.last_internal_invasion_id, grid_offset);
+            }
+            break;
+        }
+        default:
+            break;
     }
 }
 

--- a/src/scenario/invasion.h
+++ b/src/scenario/invasion.h
@@ -18,6 +18,8 @@ int scenario_invasion_start_from_caesar(int size);
 
 void scenario_invasion_start_from_cheat(void);
 
+void scenario_invasion_start_from_console(int attack_type, int size, int invasion_point);
+
 void scenario_invasion_process(void);
 
 void scenario_invasion_save_state(buffer *invasion_id, buffer *warnings);

--- a/src/widget/city.c
+++ b/src/widget/city.c
@@ -10,6 +10,7 @@
 #include "core/direction.h"
 #include "core/string.h"
 #include "figure/formation_legion.h"
+#include "game/cheats.h"
 #include "game/settings.h"
 #include "game/state.h"
 #include "graphics/graphics.h"
@@ -557,6 +558,12 @@ void widget_city_get_tooltip(tooltip_context *c)
     int grid_offset = data.current_tile.grid_offset;
     int building_id = map_building_at(grid_offset);
     int overlay = game_state_overlay();
+    // cheat tooltips
+    if(overlay == OVERLAY_NONE && game_cheat_tooltip_enabled()){
+        c->type = TOOLTIP_TILES;
+        c->high_priority = 1;
+        return;
+    }
     // regular tooltips
     if (overlay == OVERLAY_NONE && building_id && building_get(building_id)->type == BUILDING_SENATE_UPGRADED) {
         c->type = TOOLTIP_SENATE;

--- a/src/window/console.c
+++ b/src/window/console.c
@@ -1,0 +1,90 @@
+#include "window/console.h"
+
+#include "city/warning.h"
+#include "core/image_group.h"
+#include "core/log.h"
+#include "core/string.h"
+#include "game/cheats.h"
+#include "graphics/graphics.h"
+#include "graphics/image_button.h"
+#include "graphics/panel.h"
+#include "graphics/lang_text.h"
+#include "graphics/text.h"
+#include "graphics/window.h"
+#include "input/input.h"
+#include "widget/input_box.h"
+
+static void send_command(int param1, int param2);
+static void button_back(int param1, int param2);
+
+static image_button image_buttons[] = {
+    {0,   2, 31, 20, IB_NORMAL, GROUP_MESSAGE_ICON,     8, button_back,  button_none, 0, 0, 1},
+    {305, 0, 27, 27, IB_NORMAL, GROUP_SIDEBAR_BUTTONS, 56, send_command, button_none, 1, 0, 1}
+};
+
+static input_box command_input = { 160, 208, 20, 2, FONT_NORMAL_WHITE };
+
+static char command[MAX_COMMAND_SIZE] = "";
+
+static void init(void)
+{
+    input_box_start(&command_input, (uint8_t *)command, MAX_COMMAND_SIZE, 1);
+}
+
+static void draw_foreground(void)
+{
+    graphics_in_dialog();
+    outer_panel_draw(128, 160, 24, 8);
+    text_draw_centered((uint8_t *)"Console", 128, 172, 384, FONT_LARGE_BLACK,0);
+    lang_text_draw(13, 5, 352, 256, FONT_NORMAL_BLACK);
+    lang_text_draw(12, 0, 200, 256, FONT_NORMAL_BLACK);
+    input_box_draw(&command_input);
+
+    image_buttons_draw(159, 249, image_buttons, 2);
+
+    graphics_reset_dialog();
+}
+
+static void handle_input(const mouse *m, const hotkeys *h)
+{
+    const mouse *m_dialog = mouse_in_dialog(m);
+    if (input_box_handle_mouse(m_dialog, &command_input) ||
+        image_buttons_handle_mouse(m_dialog, 159, 249, image_buttons, 2, 0)) {
+        return;
+    }
+    if (input_box_is_accepted(&command_input)) {
+        send_command(0,0);
+        return;
+    }
+    if (input_go_back_requested(m, h)) {
+        button_back(0, 0);
+    }
+}
+
+static void button_back(int param1, int param2)
+{
+    input_box_stop(&command_input);
+    window_go_back();
+}
+
+static void send_command(int param1, int param2)
+{
+    uint8_t command_copy[MAX_COMMAND_SIZE]; 
+    string_copy(command_input.text,command_copy,MAX_COMMAND_SIZE);
+    button_back(0,0);
+    log_info("Command received: ",(char *)command_copy,0);
+    city_warning_show_console(command_copy);
+    game_cheat_parse_command(command_copy);
+
+}
+
+void window_console_show(){
+    window_type window = {
+        WINDOW_FILE_DIALOG,
+        window_draw_underlying_window,
+        draw_foreground,
+        handle_input
+    };
+    init();
+    window_show(&window);
+}

--- a/src/window/console.h
+++ b/src/window/console.h
@@ -1,0 +1,5 @@
+#ifndef WINDOW_CONSOLE_H
+#define WINDOW_CONSOLE_H
+
+void window_console_show(void);
+#endif // WINDOW_CONSOLE_H

--- a/test/stub/ui.c
+++ b/test/stub/ui.c
@@ -65,3 +65,9 @@ int window_building_info_get_building_type(void)
 {
     return 0;
 }
+
+void window_city_show(void)
+{}
+
+void window_console_show(int type, int dialog_type)
+{}


### PR DESCRIPTION
I added a console interface so that it is possible to launch custom commands. I split this in three commits so that it's easier to look at the functionalities
e380f73 adds the console interface and the interaction with the cheat class + a simple command to add a custom amount of money
8378d94 adds two more simple commands to cast blessing and advance to next year
e380f73 adds two advanced commands to start a custom invasion and enable a tooltip that shows the coords of the tile under the mouse. These two are a bit more invasive in the repository code, so i thought it would be better to keep them in a separate commit for easier inspection.

The commands are:
"addmoney x" - where x is a number that represents the amount you want to add
"nextyear" - to advance to the next year
"blessing x" - where x is a number from 0 to 4 that represents the god (god_type in city/constants.h)
"startinvasion type size point" - where type represents the attackers type (0 for barbarian, 1 for caesar's legion, 2 for natives), size is the amount of attackers (from 0 to 150) and point is the invasion point.
"showtooltip enabled" - where enabled is a number (0 for disabled, others for enabled) 

The console can be opened with ALT+x after enabling cheats. There's also an ALT+b function that does nothing, I use this to force the game into a breakpoint (I can't insert breakpoints while the game is running and not on a breakpoint in vscode+ mingw)

![cheat](https://user-images.githubusercontent.com/4594052/87225597-a046fa80-c38e-11ea-966f-e890d31c4690.PNG)
![console](https://user-images.githubusercontent.com/4594052/87225598-a1782780-c38e-11ea-8a25-4ee5cba83f25.PNG)
![enemy](https://user-images.githubusercontent.com/4594052/87225599-a1782780-c38e-11ea-8c8c-0e0a67414726.PNG)
