### PR TITLE
Fix asm call without compatability check causing compiler errors

### DIFF
--- a/src/game/cheats.c
+++ b/src/game/cheats.c
@@ -103,9 +103,11 @@ void game_cheat_victory(void)
 }
 
 void game_cheat_breakpoint(){
+#if defined(__GNUC__) || defined(__MINGW32__)
     if (data.is_cheating) {
         asm("nop");
     }
+#endif
 }
 
 void game_cheat_console(){


### PR DESCRIPTION
Should we even *have* an `asm` call? I'm still not sure this will work on 64-bit compilation for gcc/mingw.