### PR TITLE
Restore zoom to the map editor

### DIFF
--- a/src/widget/map_editor.c
+++ b/src/widget/map_editor.c
@@ -367,6 +367,7 @@ void widget_map_editor_handle_input(const mouse *m, const hotkeys *h)
 
     map_tile *tile = &data.current_tile;
     update_city_view_coords(m->x, m->y, tile);
+    zoom_map(m);
 
     if (!tile->grid_offset) {
         return;


### PR DESCRIPTION
When adding mouse drag to scroll, zoom in the scenario editor was disabled.

This PR restores the zoom to the scenario editor.