### PR TITLE
Get rid of max building limits

### DIFF
--- a/src/building/barracks.c
+++ b/src/building/barracks.c
@@ -28,7 +28,7 @@ int building_get_barracks_for_weapon(int x, int y, int resource, int road_networ
 	}
 	int min_dist = INFINITE;
 	building* min_building = 0;
-	for (int i = 1; i < MAX_BUILDINGS; i++) {
+	for (int i = 1; i < building_count(); i++) {
 		building* b = building_get(i);
 		if (b->state != BUILDING_STATE_IN_USE || (b->type != BUILDING_BARRACKS && b->type != BUILDING_GRAND_TEMPLE_MARS)) {
 			continue;
@@ -102,7 +102,7 @@ static int get_closest_military_academy(const building *fort)
 {
     int min_building_id = 0;
     int min_distance = INFINITE;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->type == BUILDING_MILITARY_ACADEMY &&
             b->num_workers >= model_get_building(BUILDING_MILITARY_ACADEMY)->laborers) {
@@ -155,7 +155,7 @@ int building_barracks_create_tower_sentry(building *barracks, int x, int y)
         return 0;
     }
     building *tower = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->type == BUILDING_TOWER && b->num_workers > 0 &&
             !b->figure_id && (b->road_network_id == barracks->road_network_id || config_get(CONFIG_GP_CH_TOWER_SENTRIES_GO_OFFROAD))) {

--- a/src/building/building.c
+++ b/src/building/building.c
@@ -23,8 +23,15 @@
 #include "menu.h"
 
 #include <string.h>
+#include <stdlib.h>
 
-static building all_buildings[MAX_BUILDINGS];
+#define BUILDING_ARRAY_SIZE_STEP 2000
+#define BUILDING_SAVEGAME_STATE_ORIGINAL_SIZE 128
+
+static struct {
+    building *all_buildings;
+    int building_array_size;
+} data;
 
 static struct {
     int highest_id_in_use;
@@ -36,18 +43,23 @@ static struct {
 
 building *building_get(int id)
 {
-    return &all_buildings[id];
+    return &data.all_buildings[id];
+}
+
+int building_count(void)
+{
+    return data.building_array_size;
 }
 
 int building_find(building_type type)
 {
-    for (int i = 1; i < MAX_BUILDINGS; ++i) {
-        building *b = building_get(i);
+    for (int i = 1; i < data.building_array_size; ++i) {
+        building *b = &data.all_buildings[i];
         if (b->state == BUILDING_STATE_IN_USE && b->type == type) {
             return i;
         }
     }
-    return MAX_BUILDINGS;
+    return 0;
 }
 
 building *building_main(building *b)
@@ -56,28 +68,53 @@ building *building_main(building *b)
         if (b->prev_part_building_id <= 0) {
             return b;
         }
-        b = &all_buildings[b->prev_part_building_id];
+        b = &data.all_buildings[b->prev_part_building_id];
     }
-    return &all_buildings[0];
+    return &data.all_buildings[0];
 }
 
 building *building_next(building *b)
 {
-    return &all_buildings[b->next_part_building_id];
+    return &data.all_buildings[b->next_part_building_id];
+}
+
+static void create_building_array(int size)
+{
+    free(data.all_buildings);
+    data.building_array_size = size;
+    data.all_buildings = malloc(size * sizeof(building));
+}
+
+static int expand_building_array(void)
+{
+    building *b = realloc(data.all_buildings, (data.building_array_size + BUILDING_ARRAY_SIZE_STEP) * sizeof(building));
+    if (!b) {
+        return 0;
+    }
+    data.all_buildings = b;
+    data.building_array_size += BUILDING_ARRAY_SIZE_STEP;
+    for (int i = data.building_array_size - BUILDING_ARRAY_SIZE_STEP; i < data.building_array_size; i++) {
+        memset(&data.all_buildings[i], 0, sizeof(building));
+        data.all_buildings[i].id = i;
+    }
+    return 1;
 }
 
 building *building_create(building_type type, int x, int y)
 {
     building *b = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
-        if (all_buildings[i].state == BUILDING_STATE_UNUSED && !game_undo_contains_building(i)) {
-            b = &all_buildings[i];
+    for (int i = 1; i < data.building_array_size; i++) {
+        if (data.all_buildings[i].state == BUILDING_STATE_UNUSED && !game_undo_contains_building(i)) {
+            b = &data.all_buildings[i];
             break;
         }
     }
     if (!b) {
-        city_warning_show(WARNING_DATA_LIMIT_REACHED);
-        return &all_buildings[0];
+        if (!expand_building_array()) {
+            city_warning_show(WARNING_DATA_LIMIT_REACHED);
+            return &data.all_buildings[0];
+        }
+        b = &data.all_buildings[data.building_array_size - BUILDING_ARRAY_SIZE_STEP];
     }
 
     const building_properties *props = building_properties_for_type(type);
@@ -238,8 +275,8 @@ void building_update_state(void)
     int wall_recalc = 0;
     int road_recalc = 0;
     int aqueduct_recalc = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
-        building *b = &all_buildings[i];
+    for (int i = 1; i < data.building_array_size; i++) {
+        building *b = &data.all_buildings[i];
         if (b->state == BUILDING_STATE_CREATED) {
             b->state = BUILDING_STATE_IN_USE;
         }
@@ -289,8 +326,8 @@ void building_update_state(void)
 
 void building_update_desirability(void)
 {
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
-        building *b = &all_buildings[i];
+    for (int i = 1; i < data.building_array_size; i++) {
+        building *b = &data.all_buildings[i];
         if (b->state != BUILDING_STATE_IN_USE) {
             continue;
         }
@@ -376,8 +413,8 @@ int building_get_highest_id(void)
 void building_update_highest_id(void)
 {
     extra.highest_id_in_use = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
-        if (all_buildings[i].state != BUILDING_STATE_UNUSED) {
+    for (int i = 1; i < data.building_array_size; i++) {
+        if (data.all_buildings[i].state != BUILDING_STATE_UNUSED) {
             extra.highest_id_in_use = i;
         }
     }
@@ -388,17 +425,16 @@ void building_update_highest_id(void)
 
 int building_mothball_toggle(building *b)
 {
-    if (b->state == BUILDING_STATE_IN_USE ) {
+    if (b->state == BUILDING_STATE_IN_USE) {
         b->state = BUILDING_STATE_MOTHBALLED;
         b->num_workers = 0;
     } else if (b->state == BUILDING_STATE_MOTHBALLED) {
         b->state = BUILDING_STATE_IN_USE;
     }
     return b->state;
-
 }
 
-int building_mothball_set(building* b, int mothball)
+int building_mothball_set(building *b, int mothball)
 {
     if (mothball) {
         if (b->state == BUILDING_STATE_IN_USE) {
@@ -449,9 +485,11 @@ void building_totals_add_corrupted_house(int unfixable)
 
 void building_clear_all(void)
 {
-    for (int i = 0; i < MAX_BUILDINGS; i++) {
-        memset(&all_buildings[i], 0, sizeof(building));
-        all_buildings[i].id = i;
+    create_building_array(BUILDING_ARRAY_SIZE_STEP);
+
+    for (int i = 0; i < data.building_array_size; i++) {
+        memset(&data.all_buildings[i], 0, sizeof(building));
+        data.all_buildings[i].id = i;
     }
     extra.highest_id_in_use = 0;
     extra.highest_id_ever = 0;
@@ -463,8 +501,12 @@ void building_clear_all(void)
 void building_save_state(buffer *buf, buffer *highest_id, buffer *highest_id_ever,
                          buffer *sequence, buffer *corrupt_houses)
 {
-    for (int i = 0; i < MAX_BUILDINGS; i++) {
-        building_state_save_to_buffer(buf, &all_buildings[i]);
+    int buf_size = 4 + data.building_array_size * BUILDING_SAVEGAME_STATE_ORIGINAL_SIZE;
+    uint8_t *buf_data = malloc(buf_size);
+    buffer_init(buf, buf_data, buf_size);
+    buffer_write_i32(buf, BUILDING_SAVEGAME_STATE_ORIGINAL_SIZE);
+    for (int i = 0; i < data.building_array_size; i++) {
+        building_state_save_to_buffer(buf, &data.all_buildings[i]);
     }
     buffer_write_i32(highest_id, extra.highest_id_in_use);
     buffer_write_i32(highest_id_ever, extra.highest_id_ever);
@@ -476,11 +518,20 @@ void building_save_state(buffer *buf, buffer *highest_id, buffer *highest_id_eve
 }
 
 void building_load_state(buffer *buf, buffer *highest_id, buffer *highest_id_ever,
-                         buffer *sequence, buffer *corrupt_houses)
+                         buffer *sequence, buffer *corrupt_houses, int includes_building_size)
 {
-    for (int i = 0; i < MAX_BUILDINGS; i++) {
-        building_state_load_from_buffer(buf, &all_buildings[i]);
-        all_buildings[i].id = i;
+    int building_size = BUILDING_SAVEGAME_STATE_ORIGINAL_SIZE;
+    int buf_size = buf->size;
+    if (includes_building_size) {
+        building_size = buffer_read_i32(buf);
+        buf_size -= 4;
+    }
+
+    create_building_array(buf_size / building_size);
+
+    for (int i = 0; i < data.building_array_size; i++) {
+        building_state_load_from_buffer(buf, &data.all_buildings[i]);
+        data.all_buildings[i].id = i;
     }
     extra.highest_id_in_use = buffer_read_i32(highest_id);
     extra.highest_id_ever = buffer_read_i32(highest_id_ever);

--- a/src/building/building.h
+++ b/src/building/building.h
@@ -4,8 +4,6 @@
 #include "building/type.h"
 #include "core/buffer.h"
 
-#define MAX_BUILDINGS 10000
-
 typedef struct {
     int id;
 
@@ -158,6 +156,8 @@ typedef struct {
 
 building *building_get(int id);
 
+int building_count(void);
+
 int building_find(building_type type);
 
 building *building_main(building *b);
@@ -210,6 +210,6 @@ void building_save_state(buffer *buf, buffer *highest_id, buffer *highest_id_eve
                          buffer *sequence, buffer *corrupt_houses);
 
 void building_load_state(buffer *buf, buffer *highest_id, buffer *highest_id_ever,
-                         buffer *sequence, buffer *corrupt_houses);
+                         buffer *sequence, buffer *corrupt_houses, int includes_building_size);
 
 #endif // BUILDING_BUILDING_H

--- a/src/building/count.c
+++ b/src/building/count.c
@@ -55,7 +55,7 @@ void building_count_update(void)
     city_buildings_reset_dock_wharf_counters();
     city_health_reset_hospital_workers();
 
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || b->house_size) {
             continue;

--- a/src/building/destruction.c
+++ b/src/building/destruction.c
@@ -154,7 +154,7 @@ void building_destroy_by_rioter(building *b)
 int building_destroy_first_of_type(building_type type)
 {
     int i = building_find(type);
-    if (i < MAX_BUILDINGS) {
+    if (i) {
         building* b = building_get(i);
         int grid_offset = b->grid_offset;
         game_undo_disable();
@@ -171,7 +171,7 @@ void building_destroy_last_placed(void)
 {
     int highest_sequence = 0;
     building *last_building = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_CREATED || b->state == BUILDING_STATE_IN_USE) {
             if (b->created_sequence > highest_sequence) {

--- a/src/building/dock.c
+++ b/src/building/dock.c
@@ -29,7 +29,7 @@ void building_dock_update_open_water_access(void)
 {
     map_point river_entry = scenario_map_river_entry();
     map_routing_calculate_distances_water_boat(river_entry.x, river_entry.y);
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && !b->house_size && b->type == BUILDING_DOCK) {
             if (map_terrain_is_adjacent_to_open_water(b->x, b->y, 3)) {

--- a/src/building/government.c
+++ b/src/building/government.c
@@ -22,7 +22,7 @@ void building_government_distribute_treasury(void)
         remainder = 0;
     }
 
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || b->house_size) {
             continue;

--- a/src/building/granary.c
+++ b/src/building/granary.c
@@ -226,7 +226,7 @@ void building_granaries_calculate_stocks(void)
     non_getting_granaries.total_storage_fruit = 0;
     non_getting_granaries.total_storage_meat = 0;
 
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || b->type != BUILDING_GRANARY) {
             continue;
@@ -274,7 +274,7 @@ int building_granary_for_storing(int x, int y, int resource, int distance_from_e
     }
     int min_dist = INFINITE;
     int min_building_id = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || b->type != BUILDING_GRANARY) {
             continue;
@@ -331,7 +331,7 @@ int building_getting_granary_for_storing(int x, int y, int resource, int distanc
     }
     int min_dist = INFINITE;
     int min_building_id = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || b->type != BUILDING_GRANARY) {
             continue;
@@ -431,7 +431,7 @@ void building_granary_bless(void)
 {
     int min_stored = INFINITE;
     building *min_building = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || b->type != BUILDING_GRANARY) {
             continue;
@@ -465,7 +465,7 @@ void building_granary_warehouse_curse(int big)
 {
     int max_stored = 0;
     building *max_building = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE) {
             continue;

--- a/src/building/house_evolution.c
+++ b/src/building/house_evolution.c
@@ -540,7 +540,7 @@ void building_house_process_evolve_and_consume_goods(void)
         active_devolve_delay = DEVOLVE_DELAY;
     }
 
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && building_is_house(b->type)) {
             building_house_check_for_corruption(b);

--- a/src/building/house_population.c
+++ b/src/building/house_population.c
@@ -15,8 +15,8 @@ int house_population_add_to_city(int num_people)
 {
     int added = 0;
     int building_id = city_population_last_used_house_add();
-    for (int i = 1; i < MAX_BUILDINGS && added < num_people; i++) {
-        if (++building_id >= MAX_BUILDINGS) {
+    for (int i = 1; i < building_count() && added < num_people; i++) {
+        if (++building_id >= building_count()) {
             building_id = 1;
         }
         building *b = building_get(building_id);
@@ -38,8 +38,8 @@ int house_population_remove_from_city(int num_people)
 {
     int removed = 0;
     int building_id = city_population_last_used_house_remove();
-    for (int i = 1; i < 4 * MAX_BUILDINGS && removed < num_people; i++) {
-        if (++building_id >= MAX_BUILDINGS) {
+    for (int i = 1; i < 4 * building_count() && removed < num_people; i++) {
+        if (++building_id >= building_count()) {
             building_id = 1;
         }
         building *b = building_get(building_id);
@@ -57,7 +57,7 @@ int house_population_remove_from_city(int num_people)
 static void fill_building_list_with_houses(void)
 {
     building_list_large_clear(0);
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->house_size) {
             building_list_large_add(i);

--- a/src/building/house_service.c
+++ b/src/building/house_service.c
@@ -15,7 +15,7 @@ static void decay(unsigned char *value)
 
 void house_service_decay_culture(void)
 {
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || !b->house_size) {
             continue;
@@ -47,7 +47,7 @@ void house_service_decay_culture(void)
 
 void house_service_decay_tax_collector(void)
 {
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->house_tax_coverage) {
             b->house_tax_coverage--;
@@ -57,7 +57,7 @@ void house_service_decay_tax_collector(void)
 
 void house_service_decay_houses_covered(void)
 {
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_UNUSED && b->type != BUILDING_TOWER) {
             if (b->houses_covered <= 1) {
@@ -76,7 +76,7 @@ void house_service_calculate_culture_aggregates(void)
     int completed_colosseum = building_monument_working(BUILDING_COLOSSEUM);
     int completed_hippodrome = building_monument_working(BUILDING_HIPPODROME);
 
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || !b->house_size) {
             continue;

--- a/src/building/industry.c
+++ b/src/building/industry.c
@@ -60,7 +60,7 @@ static void building_other_update_production(building* b) {
 
 void building_industry_update_production(void)
 {
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
        
         if (b->state != BUILDING_STATE_IN_USE || !b->output_resource_id) {
@@ -111,7 +111,7 @@ void building_industry_update_wheat_production(void)
     if (scenario_property_climate() == CLIMATE_NORTHERN) {
         return;
     }
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || !b->output_resource_id) {
             continue;
@@ -155,7 +155,7 @@ void building_industry_start_new_production(building *b)
 
 void building_bless_farms(void)
 {
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->output_resource_id && building_is_farm(b->type)) {
             b->data.industry.progress = MAX_PROGRESS_RAW;
@@ -168,7 +168,7 @@ void building_bless_farms(void)
 
 void building_bless_industry(void)
 {
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building* b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && building_is_workshop(b->type) && b->loads_stored) {
             if (b->loads_stored < MERCURY_BLESSING_LOADS) {
@@ -181,7 +181,7 @@ void building_bless_industry(void)
 
 void building_curse_farms(int big_curse)
 {
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->output_resource_id && building_is_farm(b->type)) {
             b->data.industry.progress = 0;
@@ -211,7 +211,7 @@ int building_get_workshop_for_raw_material_with_room(
     }
     int min_dist = INFINITE;
     building *min_building = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || !building_is_workshop(b->type)) {
             continue;
@@ -249,7 +249,7 @@ int building_get_workshop_for_raw_material(
     }
     int min_dist = INFINITE;
     building *min_building = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || !building_is_workshop(b->type)) {
             continue;

--- a/src/building/maintenance.c
+++ b/src/building/maintenance.c
@@ -40,7 +40,7 @@ void building_maintenance_update_burning_ruins(void)
     scenario_climate climate = scenario_property_climate();
     int recalculate_terrain = 0;
     building_list_burning_clear();
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if ((b->state != BUILDING_STATE_IN_USE && b->state != BUILDING_STATE_MOTHBALLED) || b->type != BUILDING_BURNING_RUIN ) {
             continue;
@@ -227,7 +227,7 @@ void building_maintenance_check_rome_access(void) {
 	const map_tile* entry_point = city_map_entry_point();
 	map_routing_calculate_distances(entry_point->x, entry_point->y);
 	int problem_grid_offset = 0;
-	for (int i = 1; i < MAX_BUILDINGS; i++) {
+	for (int i = 1; i < building_count(); i++) {
 		building* b = building_get(i);
 		if (b->state != BUILDING_STATE_IN_USE) {
 			continue;

--- a/src/building/market.c
+++ b/src/building/market.c
@@ -116,7 +116,7 @@ int building_market_get_storage_destination(building *market)
     } else {
         permission = BUILDING_STORAGE_PERMISSION_MARKET;
     }
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
 
         if (b->state != BUILDING_STATE_IN_USE) {

--- a/src/building/monument.c
+++ b/src/building/monument.c
@@ -808,7 +808,7 @@ void building_monument_recalculate_monuments() {
 	data.monuments_number = 0;
 	data.unfinished_monuments = 0;
 
-	for (int i = 0; i < MAX_BUILDINGS; i++) {
+	for (int i = 0; i < building_count(); i++) {
 		building* b = building_get(i);
 		if (building_monument_is_monument(b)) {
 			data.monuments_number++;

--- a/src/building/storage.c
+++ b/src/building/storage.c
@@ -28,7 +28,7 @@ void building_storage_reset_building_ids(void)
         data.storages[i].building_id = 0;
     }
 
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_UNUSED) {
             continue;

--- a/src/building/warehouse.c
+++ b/src/building/warehouse.c
@@ -205,9 +205,9 @@ void building_warehouse_space_remove_export(building *space, int resource)
 void building_warehouses_add_resource(int resource, int amount)
 {
     int building_id = city_resource_last_used_warehouse();
-    for (int i = 1; i < MAX_BUILDINGS && amount > 0; i++) {
+    for (int i = 1; i < building_count() && amount > 0; i++) {
         building_id++;
-        if (building_id >= MAX_BUILDINGS) {
+        if (building_id >= building_count()) {
             building_id = 1;
         }
         building *b = building_get(building_id);
@@ -301,9 +301,9 @@ int building_warehouses_remove_resource(int resource, int amount)
     int amount_left = amount;
     int building_id = city_resource_last_used_warehouse();
     // first go for non-getting warehouses
-    for (int i = 1; i < MAX_BUILDINGS && amount_left > 0; i++) {
+    for (int i = 1; i < building_count() && amount_left > 0; i++) {
         building_id++;
-        if (building_id >= MAX_BUILDINGS) {
+        if (building_id >= building_count()) {
             building_id = 1;
         }
         building *b = building_get(building_id);
@@ -315,9 +315,9 @@ int building_warehouses_remove_resource(int resource, int amount)
         }
     }
     // if that doesn't work, take it anyway
-    for (int i = 1; i < MAX_BUILDINGS && amount_left > 0; i++) {
+    for (int i = 1; i < building_count() && amount_left > 0; i++) {
         building_id++;
-        if (building_id >= MAX_BUILDINGS) {
+        if (building_id >= building_count()) {
             building_id = 1;
         }
         building *b = building_get(building_id);
@@ -335,7 +335,7 @@ int building_warehouse_for_storing(int src_building_id, int x, int y, int resour
 {
     int min_dist = 10000;
     int min_building_id = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || b->type != BUILDING_WAREHOUSE_SPACE) {
             continue;
@@ -384,7 +384,7 @@ int building_warehouse_for_getting(building *src, int resource, map_point *dst)
 {
     int min_dist = 10000;
     building *min_building = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || b->type != BUILDING_WAREHOUSE) {
             continue;
@@ -428,7 +428,7 @@ int building_warehouse_with_resource(int src_building_id, int x, int y, int reso
 {
     int min_dist = 10000;
     building* min_building = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building* b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || b->type != BUILDING_WAREHOUSE_SPACE) {
             continue;
@@ -485,7 +485,7 @@ static int determine_granary_accept_foods(int resources[RESOURCE_MAX_FOOD], int 
         resources[i] = 0;
     }
     int can_accept = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || b->type != BUILDING_GRANARY || !b->has_road_access) {
             continue;
@@ -518,7 +518,7 @@ static int determine_granary_get_foods(int resources[RESOURCE_MAX_FOOD], int roa
         resources[i] = 0;
     }
     int can_get = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || b->type != BUILDING_GRANARY || !b->has_road_access) {
             continue;

--- a/src/city/culture.c
+++ b/src/city/culture.c
@@ -202,7 +202,7 @@ void city_culture_calculate(void)
     city_data.culture.population_with_venus_access = 0; //venus
 
     int num_houses = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->house_size) {
             num_houses++;

--- a/src/city/entertainment.c
+++ b/src/city/entertainment.c
@@ -50,7 +50,7 @@ void city_entertainment_calculate_shows(void)
     city_data.entertainment.hippodrome_no_shows_weighted = 0;
     city_data.entertainment.venue_needing_shows = 0;
 
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE) {
             continue;

--- a/src/city/finance.c
+++ b/src/city/finance.c
@@ -180,7 +180,7 @@ void city_finance_estimate_taxes(void)
 {
     city_data.taxes.monthly.collected_plebs = 0;
     city_data.taxes.monthly.collected_patricians = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->house_size && b->house_tax_coverage) {
             int is_patrician = b->subtype.house_level >= HOUSE_SMALL_VILLA;
@@ -220,7 +220,7 @@ static void collect_monthly_taxes(void)
     for (int i = 0; i < MAX_HOUSE_LEVELS; i++) {
         city_data.population.at_level[i] = 0;
     }
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || !b->house_size) {
             continue;
@@ -309,7 +309,7 @@ static void pay_monthly_salary(void)
 
 static void pay_monthly_building_levies(void) {
     int levies = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building* b = building_get(i);
         for (int i = 0; i < BUILDINGS_WITH_LEVIES; ++i) {
             if (b->type == building_levies[i].type) {
@@ -332,7 +332,7 @@ static void collect_monthly_tourism(void) {
         int num_buildings = calc_bound(building_count_active(tourism_modifiers[i].type), 0, city_data.population.population / tourism_modifiers[i].coverage);
         tourism_modifiers[i].total = num_buildings * tourism_modifiers[i].amount * (TOURISM_RATING_MODIFIER * city_finance_tourism_rating());
 
-        for (int i = 1; i < MAX_BUILDINGS; i++) {
+        for (int i = 1; i < building_count(); i++) {
             building* b = building_get(i);
             for (int i = 0; i < BUILDINGS_WITH_TOURISM; ++i) {
                 if (b->type == tourism_modifiers[i].type && b->state == BUILDING_STATE_IN_USE && b->num_workers) {
@@ -369,7 +369,7 @@ static void reset_taxes(void)
     city_data.taxes.yearly.uncollected_patricians = 0;
 
     // reset tax income in building list
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->house_size) {
             b->tax_income_or_storage = 0;

--- a/src/city/health.c
+++ b/src/city/health.c
@@ -51,7 +51,7 @@ static void cause_disease(int total_people)
     }
     tutorial_on_disease();
     // kill people who don't have access to a doctor
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->house_size && b->house_population) {
             if (!b->data.house.clinic) {
@@ -64,7 +64,7 @@ static void cause_disease(int total_people)
         }
     }
     // kill people in tents
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->house_size && b->house_population) {
             if (b->subtype.house_level <= HOUSE_LARGE_TENT) {
@@ -77,7 +77,7 @@ static void cause_disease(int total_people)
         }
     }
     // kill anyone
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->house_size && b->house_population) {
             people_to_kill -= b->house_population;
@@ -98,7 +98,7 @@ void city_health_update(void)
     }
     int total_population = 0;
     int healthy_population = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || !b->house_size || !b->house_population) {
             continue;

--- a/src/city/labor.c
+++ b/src/city/labor.c
@@ -191,7 +191,7 @@ static void calculate_workers_needed_per_category(void)
         city_data.labor.categories[cat].workers_allocated = 0;
         city_data.labor.categories[cat].workers_needed = 0;
     }
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE) {
             continue;
@@ -313,7 +313,7 @@ static void check_employment(void)
 static void set_building_worker_weight(void)
 {
     int water_per_10k_per_building = calc_percentage(100, city_data.labor.categories[LABOR_CATEGORY_WATER].buildings);
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE) {
             continue;
@@ -349,8 +349,8 @@ static void allocate_workers_to_water(void)
     }
     int building_id = start_building_id;
     start_building_id = 0;
-    for (int guard = 1; guard < MAX_BUILDINGS; guard++, building_id++) {
-        if (building_id >= MAX_BUILDINGS) {
+    for (int guard = 1; guard < building_count(); guard++, building_id++) {
+        if (building_id >= building_count()) {
             building_id = 1;
         }
         building *b = building_get(building_id);
@@ -389,7 +389,7 @@ static void allocate_workers_to_non_water_buildings(void)
             city_data.labor.categories[i].workers_allocated < city_data.labor.categories[i].workers_needed
             ? 1 : 0;
     }
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE) {
             continue;
@@ -431,7 +431,7 @@ static void allocate_workers_to_non_water_buildings(void)
             }
         }
     }
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE) {
             continue;

--- a/src/city/population.c
+++ b/src/city/population.c
@@ -362,7 +362,7 @@ static void yearly_recalculate_population(void)
 int calculate_total_housing_buildings(void)
 {
     int total = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_UNUSED ||
             b->state == BUILDING_STATE_UNDO ||
@@ -386,7 +386,7 @@ int * calculate_number_of_each_housing_type(void) {
         housing_type_counts[i] = 0;
     }
 
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_UNUSED ||
             b->state == BUILDING_STATE_UNDO ||
@@ -439,7 +439,7 @@ static int calculate_people_per_house_type(void)
     city_data.population.people_in_tents = 0;
     city_data.population.people_in_large_insula_and_above = 0;
     int total = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_UNUSED ||
             b->state == BUILDING_STATE_UNDO ||

--- a/src/city/ratings.c
+++ b/src/city/ratings.c
@@ -468,7 +468,7 @@ static void calculate_max_prosperity(void)
 {
     int points = 0;
     int houses = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state && b->house_size) {
             points += model_get_house(b->subtype.house_level)->prosperity;

--- a/src/city/resource.c
+++ b/src/city/resource.c
@@ -185,7 +185,7 @@ void city_resource_calculate_warehouse_stocks(void)
         city_data.resource.space_in_warehouses[i] = 0;
         city_data.resource.stored_in_warehouses[i] = 0;
     }
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->type == BUILDING_WAREHOUSE) {
             b->has_road_access = 0;
@@ -196,7 +196,7 @@ void city_resource_calculate_warehouse_stocks(void)
             }
         }
     }
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || b->type != BUILDING_WAREHOUSE_SPACE) {
             continue;
@@ -282,7 +282,7 @@ static void calculate_available_food(void)
     city_data.resource.granaries.understaffed = 0;
     city_data.resource.granaries.not_operating = 0;
     city_data.resource.granaries.not_operating_with_food = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || b->type != BUILDING_GRANARY) {
             continue;
@@ -340,7 +340,7 @@ void city_resource_calculate_food_stocks_and_supply_wheat(void)
 {
     calculate_available_food();
     if (scenario_property_rome_supplies_wheat()) {
-        for (int i = 1; i < MAX_BUILDINGS; i++) {
+        for (int i = 1; i < building_count(); i++) {
             building *b = building_get(i);
             if (b->state == BUILDING_STATE_IN_USE && (b->type == BUILDING_MARKET || b->type == BUILDING_MESS_HALL)) {
                 b->data.market.inventory[INVENTORY_WHEAT] = 200;
@@ -355,7 +355,7 @@ void city_resource_calculate_workshop_stocks(void)
         city_data.resource.stored_in_workshops[i] = 0;
         city_data.resource.space_in_workshops[i] = 0;
     }
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || !building_is_workshop(b->type)) {
             continue;
@@ -383,7 +383,7 @@ void city_resource_consume_food(void)
     int ceres_module = (building_monument_gt_module_is_active(CERES_MODULE_1_REDUCE_FOOD));
     int total_consumed = 0;
 
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building* b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->house_size) {
             int num_types = model_get_house(b->subtype.house_level)->food_types;

--- a/src/city/sentiment.c
+++ b/src/city/sentiment.c
@@ -41,7 +41,7 @@ int city_sentiment_low_mood_cause(void)
 
 void city_sentiment_change_happiness(int amount)
 {
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->house_size) {
             b->sentiment.house_happiness = calc_bound(b->sentiment.house_happiness + amount, 0, 100);
@@ -51,7 +51,7 @@ void city_sentiment_change_happiness(int amount)
 
 void city_sentiment_set_max_happiness(int max)
 {
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->house_size) {
             if (b->sentiment.house_happiness > max) {
@@ -216,7 +216,7 @@ static int calc_average_housing_level(void) {
     int avg = 0;
     int num_houses = 0;
 
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building* b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->house_size && b->house_population) {
             avg += b->subtype.house_level;
@@ -278,7 +278,7 @@ void city_sentiment_update(void)
     int blessing_festival_sentiment_boost = city_data.sentiment.blessing_festival_sentiment_boost;
     int average_squalor_penalty = 0;
 
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building* b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || !b->house_size) {
             continue;
@@ -365,7 +365,7 @@ void city_sentiment_update(void)
     int total_sentiment = 0;
     int total_pop = 0;
     int total_houses = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building* b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->house_size && b->house_population) {
             total_pop += b->house_population;

--- a/src/figure/formation_enemy.c
+++ b/src/figure/formation_enemy.c
@@ -140,7 +140,7 @@ int formation_rioter_get_target_building(int *x_tile, int *y_tile)
 {
     int best_type_index = 100;
     building *best_building = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE) {
             continue;
@@ -178,7 +178,7 @@ static void set_enemy_target_building(formation *m)
     int best_type_index = 100;
     building *best_building = 0;
     int min_distance = 10000;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || map_soldier_strength_get(b->grid_offset)) {
             continue;
@@ -200,7 +200,7 @@ static void set_enemy_target_building(formation *m)
     }
     if (!best_building) {
         // no target buildings left: take rioter attack priority
-        for (int i = 1; i < MAX_BUILDINGS; i++) {
+        for (int i = 1; i < building_count(); i++) {
             building *b = building_get(i);
             if (b->state != BUILDING_STATE_IN_USE || map_soldier_strength_get(b->grid_offset)) {
                 continue;
@@ -236,7 +236,7 @@ static void set_native_target_building(formation *m)
     city_buildings_main_native_meeting_center(&meeting_x, &meeting_y);
     building *min_building = 0;
     int min_distance = 10000;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE) {
             continue;

--- a/src/figuretype/docker.c
+++ b/src/figuretype/docker.c
@@ -102,7 +102,7 @@ static int get_closest_warehouse_for_import(int x, int y, int city_id, int dista
     }
     int min_distance = 10000;
     int min_building_id = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || b->type != BUILDING_WAREHOUSE) {
             continue;
@@ -171,7 +171,7 @@ static int get_closest_warehouse_for_export(int x, int y, int city_id, int dista
     }
     int min_distance = 10000;
     int min_building_id = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || b->type != BUILDING_WAREHOUSE) {
             continue;

--- a/src/figuretype/entertainer.c
+++ b/src/figuretype/entertainer.c
@@ -19,7 +19,7 @@ static int determine_destination(int x, int y, building_type type1, building_typ
 
     building_list_small_clear();
 
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE) {
             continue;

--- a/src/figuretype/trader.c
+++ b/src/figuretype/trader.c
@@ -272,7 +272,7 @@ static int get_closest_warehouse(const figure *f, int x, int y, int city_id, int
     }
     int min_distance = 10000;
     building *min_building = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || b->type != BUILDING_WAREHOUSE) {
             continue;

--- a/src/game/file.c
+++ b/src/game/file.c
@@ -227,7 +227,7 @@ static void check_hippodrome_compatibility(building *b){
 }
 
 static void check_backward_compatibility(void){
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if(b->type == BUILDING_HIPPODROME){
             check_hippodrome_compatibility(b);

--- a/src/game/undo.c
+++ b/src/game/undo.c
@@ -111,7 +111,7 @@ int game_undo_start_build(building_type type)
     data.building_cost = 0;
     data.type = type;
     clear_buildings();
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_UNDO) {
             data.available = 0;

--- a/src/map/natives.c
+++ b/src/map/natives.c
@@ -55,7 +55,7 @@ static void determine_meeting_center(void)
 {
     // gather list of meeting centers
     building_list_small_clear();
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->type == BUILDING_NATIVE_MEETING) {
             building_list_small_add(i);
@@ -67,7 +67,7 @@ static void determine_meeting_center(void)
     }
     const int *meetings = building_list_small_items();
     // determine closest meeting center for hut
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->type == BUILDING_NATIVE_HUT) {
             int min_dist = 1000;
@@ -201,7 +201,7 @@ void map_natives_check_land(void)
     map_property_clear_all_native_land();
     city_military_decrease_native_attack_duration();
 
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE) {
             continue;

--- a/src/map/orientation.c
+++ b/src/map/orientation.c
@@ -244,7 +244,7 @@ void map_orientation_update_buildings(void)
 {
     int map_orientation = city_view_orientation();
     int orientation_is_top_bottom = map_orientation == DIR_0_TOP || map_orientation == DIR_4_BOTTOM;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_UNUSED) {
             continue;

--- a/src/map/water.c
+++ b/src/map/water.c
@@ -208,7 +208,7 @@ int map_water_determine_orientation_size3(int x, int y, int adjust_xy,
 int map_water_get_wharf_for_new_fishing_boat(figure *boat, map_point *tile)
 {
     building *wharf = 0;
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->type == BUILDING_WHARF) {
             int wharf_boat_id = b->data.industry.fishing_boat_id;

--- a/src/map/water_supply.c
+++ b/src/map/water_supply.c
@@ -52,7 +52,7 @@ static void mark_well_access(int well_id, int radius)
 void map_water_supply_update_houses(void)
 {
     building_list_small_clear();
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE) {
             continue;
@@ -155,7 +155,7 @@ void map_water_supply_update_reservoir_fountain(void)
     set_all_aqueducts_to_no_water();
     building_list_large_clear(1);
     // mark reservoirs next to water
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state == BUILDING_STATE_IN_USE && b->type == BUILDING_RESERVOIR) {
             building_list_large_add(i);
@@ -199,7 +199,7 @@ void map_water_supply_update_reservoir_fountain(void)
     }
 
     // fountains
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE || b->type != BUILDING_FOUNTAIN) {
             continue;
@@ -225,7 +225,7 @@ void map_water_supply_update_reservoir_fountain(void)
         }
     }
     //ponds
-    for (int i = 1; i < MAX_BUILDINGS; i++) {
+    for (int i = 1; i < building_count(); i++) {
         building* b = building_get(i);
 
         if (b->type != BUILDING_SMALL_POND && b->type != BUILDING_LARGE_POND) {

--- a/src/scenario/random_event.c
+++ b/src/scenario/random_event.c
@@ -98,7 +98,7 @@ static void destroy_iron_mine(void)
 {
     if (scenario.random_events.iron_mine_collapse) {
         if(config_get(CONFIG_GP_CH_RANDOM_COLLAPSES_TAKE_MONEY)) {
-            if(building_find(BUILDING_IRON_MINE) < MAX_BUILDINGS) {
+            if(building_find(BUILDING_IRON_MINE)) {
                 city_finance_process_sundry(250);
                 city_message_post(1, MESSAGE_IRON_MINE_COLLAPED, 0, 0);
             }
@@ -115,7 +115,7 @@ static void destroy_clay_pit(void)
 {
     if (scenario.random_events.clay_pit_flooded) {
         if(config_get(CONFIG_GP_CH_RANDOM_COLLAPSES_TAKE_MONEY)) {
-            if(building_find(BUILDING_CLAY_PIT) < MAX_BUILDINGS) {
+            if(building_find(BUILDING_CLAY_PIT)) {
                 city_finance_process_sundry(250);
                 city_message_post(1, MESSAGE_CLAY_PIT_FLOODED, 0, 0);
             }


### PR DESCRIPTION
Make the building array dynamic, allowing for unlimited buildings

Allow savegames to have pieces with dynamic sizes (future-proofing the savefile format and easing the removal of the other hardcoded limits, such as walkers)

This needs testing before merging to the release branch