### PR TITLE
Fixes for great temples and priests with a pantheon

### DIFF
--- a/src/building/figure.c
+++ b/src/building/figure.c
@@ -972,6 +972,16 @@ static void spawn_figure_grand_temple_mars(building* b) {
             }
 
         }
+
+        // Pantheon Module 1 Bonus
+        if (!b->figure_id4 && building_monument_pantheon_module_is_active(PANTHEON_MODULE_1_DESTINATION_PRIESTS)) {
+            figure* f = figure_create(FIGURE_PRIEST, road.x, road.y, DIR_4_BOTTOM);
+            int pantheon_id = building_monument_working(BUILDING_PANTHEON);
+            b->figure_id4 = f->id;
+            f->destination_building_id = pantheon_id;
+            f->building_id = b->id;
+            f->action_state = FIGURE_ACTION_212_DESTINATION_PRIEST_CREATED;
+        }
     }
 }
 

--- a/src/building/figure.c
+++ b/src/building/figure.c
@@ -1058,7 +1058,7 @@ static void spawn_figure_temple(building *b)
         }
 
         // Pantheon Module 1 Bonus
-        if (!b->figure_id4 && building_monument_pantheon_module_is_active(PANTHEON_MODULE_1_DESTINATION_PRIESTS)) {
+        if (b->type != BUILDING_PANTHEON && !b->figure_id4 && building_monument_pantheon_module_is_active(PANTHEON_MODULE_1_DESTINATION_PRIESTS)) {
             figure* f = figure_create(FIGURE_PRIEST, road.x, road.y, DIR_4_BOTTOM);
             int pantheon_id = building_monument_working(BUILDING_PANTHEON);
             b->figure_id4 = f->id;


### PR DESCRIPTION
This PR adds missing code to make Mars great temples send priests to the pantheon and prevents the pantheon from sending a priest to the pantheon when you choose the pantheon Ara Maxima bonus.
 
Let me know if it needs any changes before merging.