### PR TITLE
Make pause popup vanish when game is unpaused and a legion is selected

### DIFF
--- a/src/window/city.c
+++ b/src/window/city.c
@@ -54,6 +54,7 @@ static void draw_background(void)
 
 static void draw_background_military(void)
 {
+    clear_city_view(1);
     if (config_get(CONFIG_UI_SHOW_MILITARY_SIDEBAR)) {
         widget_sidebar_military_draw_background();
     } else {
@@ -136,6 +137,7 @@ static void draw_foreground(void)
 
 static void draw_foreground_military(void)
 {
+    clear_city_view(0);
     widget_top_menu_draw(0);
     window_city_draw();
     if (config_get(CONFIG_UI_SHOW_MILITARY_SIDEBAR)) {


### PR DESCRIPTION
Seems to only happen with the zoom and military sidebar features enabled.

Since ```clear_city_view``` is already called in ```draw_foreground```, I added it in ```draw_foreground_military```. I am not sure if I should add it to ```draw_background_military``` as well as there is also a call to ```clear_city_view``` in ```draw_background```. It doesn't change anything regarding to this bug at least.