### PR TITLE
Fix black screen on window_plain_message_dialog_show()

### DIFF
--- a/src/window/plain_message_dialog.c
+++ b/src/window/plain_message_dialog.c
@@ -33,6 +33,8 @@ static int init(translation_key title, translation_key message)
 
 static void draw_background(void)
 {
+    window_draw_underlying_window();
+
     graphics_in_dialog();
     outer_panel_draw(80, 80, 30, 12);
     text_draw_centered(data.title, 80, 100, 480, FONT_LARGE_BLACK, 0);


### PR DESCRIPTION
Is this correct behavior in **Augustus**? If not, maybe it's more "deep" bug, because **plain_message_dialog.c** file is identical in both repositories. Or render process is changed in comparison with **Julius**?
**Julius** (v1.6.0)
![Julius](https://user-images.githubusercontent.com/964801/104126022-f0654080-5362-11eb-9746-7f61fc289fe6.jpg)
**Augustus** (v2.0.1) or (built from **master** branch)
![Augustus](https://user-images.githubusercontent.com/964801/104126030-f9561200-5362-11eb-8dbc-06b7d2f47c99.jpg)
