### PR TITLE
Fix path facing wrong direction when placing from a non-North view

### DIFF
--- a/src/building/construction.c
+++ b/src/building/construction.c
@@ -532,8 +532,8 @@ void building_construction_update(int x, int y, int grid_offset)
         if (items_placed >= 0) current_cost *= items_placed;
     }
     else if (type >= BUILDING_PINE_PATH && type <= BUILDING_DATE_PATH) {
-        int rotation = building_rotation_get_rotation();
-        int image_id = mods_get_group_id("Areldir", "Aesthetics") + (type - BUILDING_PINE_TREE) + (rotation % 2 * PATH_ROTATE_OFFSET);
+        int orientation = building_rotation_get_building_orientation(building_rotation_get_rotation());
+        int image_id = mods_get_group_id("Areldir", "Aesthetics") + (type - BUILDING_PINE_TREE) + (((orientation / 2) % 2) * PATH_ROTATE_OFFSET);
         int items_placed = plot_draggable_building(data.start.x, data.start.y, x, y, type, image_id); 
         if (items_placed >= 0) current_cost *= items_placed;
     } else if (type == BUILDING_LOW_BRIDGE || type == BUILDING_SHIP_BRIDGE) {
@@ -749,8 +749,9 @@ void building_construction_place(void)
     }
     else if (type >= BUILDING_PINE_PATH && type <= BUILDING_DATE_PATH) {
         int rotation = building_rotation_get_rotation();
-        int image_id = mods_get_group_id("Areldir", "Aesthetics") + (type - BUILDING_PINE_TREE) + (rotation % 2 * PATH_ROTATE_OFFSET);
-        placement_cost *= place_draggable_building(x_start, y_start, x_end, y_end, type, image_id, rotation % 2);
+        int orientation = building_rotation_get_building_orientation(rotation);
+        int image_id = mods_get_group_id("Areldir", "Aesthetics") + (type - BUILDING_PINE_TREE) + (((orientation / 2) % 2) * PATH_ROTATE_OFFSET);
+        placement_cost *= place_draggable_building(x_start, y_start, x_end, y_end, type, image_id, rotation);
     } else if (type == BUILDING_HOUSE_VACANT_LOT) {
         placement_cost *= place_houses(0, x_start, y_start, x_end, y_end);
     } else if (!building_construction_place_building(type, x_end, y_end)) {

--- a/src/city/buildings.c
+++ b/src/city/buildings.c
@@ -66,7 +66,7 @@ void city_buildings_set_barracks(int building_id)
 
 int city_buildings_has_mess_hall(void)
 {
-	return city_data.building.mess_hall_building_id > 0;
+    return city_data.building.mess_hall_building_id > 0;
 }
 
 void city_buildings_add_mess_hall(building *mess_hall)

--- a/src/map/orientation.c
+++ b/src/map/orientation.c
@@ -18,7 +18,6 @@
 #include "map/water.h"
 #include "mods/mods.h"
 
-#include <math.h>
 #include <stdlib.h>
 
 
@@ -350,7 +349,8 @@ void map_orientation_update_buildings(void)
                 break;
         }
         if (b->type >= BUILDING_PINE_PATH && b->type <= BUILDING_DATE_PATH) {
-            image_id = mods_get_group_id("Areldir", "Aesthetics") + (b->type - BUILDING_PINE_TREE) + (abs((b->subtype.orientation - (map_orientation / 2) % 2)) * PATH_ROTATE_OFFSET);
+            int orientation = building_rotation_get_building_orientation(b->subtype.orientation);
+            image_id = mods_get_group_id("Areldir", "Aesthetics") + (b->type - BUILDING_PINE_TREE) + (((orientation / 2) % 2) * PATH_ROTATE_OFFSET);
             map_building_tiles_add(i, b->x, b->y, 1, image_id, TERRAIN_BUILDING);
         }
     }

--- a/src/widget/city_building_ghost.c
+++ b/src/widget/city_building_ghost.c
@@ -351,7 +351,8 @@ static void draw_default(const map_tile* tile, int x_view, int y_view, building_
         // hack for offsets, not perfect
         int y_offset = (building_size - 1) * MOD_IMAGE_X_OFFSET;
         int x_offset = (building_size - 1) * MOD_IMAGE_Y_OFFSET;
-        int rotation_offset = building_rotation_get_rotation() % 2 * props->rotation_offset;
+        int building_orientation = building_rotation_get_building_orientation(building_rotation_get_rotation());
+        int rotation_offset = ((building_orientation / 2) % 2) * props->rotation_offset;
         image_id = props->image_group+rotation_offset;
         draw_regular_building(type, image_id, x_view- x_offset, y_view+ y_offset, grid_offset);
     } else {


### PR DESCRIPTION
This was a bug reported a few days ago on discord.

Not sure if it was already fixed in another branch but as I did a fix a few days ago, here is the PR for that.

To be honest, I don't like my fix, I think I have changed too many things but I couldn't figure a way to do it in another way while still being consistent with the original C3 buildings behavior. If you have a better way to do it, I would gladly appreciate that you merge your fix instead.

The main fix is that the path is now facing the correct direction when placing it in a non-North view, but I also modified the behavior a bit to match the other rotated buildings behavior: when you rotate e.g. an hippodrome, it faces a direction (let's say North-East), and if you rotate the map after, it will still face that direction (still North-East), independently from the map orientation. The same applies for the gatehouse and the triumphal arch if I am not mistaken.

Code wise, this is a mess if we look at all the rotated buildings, but this was already before I changed anything: gatehouses and triumphal arches seem to use some kind of magic numbers to save their orientation (1-2 and 1-3), the hippodrome saves its rotation whereas the pathes saved their orientation. The water buildings (dock, etc...) are another case, but they are handled a bit differently.

For this fix, I tried to approach the coding used for the hippodrome (saving the rotation instead of the orientation) but this results in another code path that is neither the one from the hippodrome, nor any other building.

Also, I did not test it extensively, and I won't be able to test it more in the near future.

_I also included a small indentation fix for one of my previous commits_