### PR TITLE
Adjust Architect guild and workcamp labor

### DIFF
--- a/src/building/model.c
+++ b/src/building/model.c
@@ -155,8 +155,8 @@ int model_load(void)
 }
 
 const model_building MODEL_ROADBLOCK = {40,0,0,0,0};
-const model_building MODEL_WORK_CAMP = { 150,-10,2,3,4,25 };
-const model_building MODEL_ARCHITECT_GUILD = { 150,-8,1,2,4,25 };
+const model_building MODEL_WORK_CAMP = { 150,-10,2,3,4,20 };
+const model_building MODEL_ARCHITECT_GUILD = { 150,-8,1,2,4,12 };
 const model_building MODEL_GRAND_TEMPLE_CERES = { 2500,20,2,-4,5,50 };
 const model_building MODEL_GRAND_TEMPLE_NEPTUNE = { 2500,20,2,-4,5,50 };
 const model_building MODEL_GRAND_TEMPLE_MERCURY = { 2500,20,2,-4,5,50 };


### PR DESCRIPTION
Adjust labor number per balancing request
```
Lower required employees for Engineer's guild and Workcamp a little. EG = 12 workers, W = 20
```