### PR TITLE
Add caravanserai policy information and fix second policy bonus

### DIFF
--- a/src/empire/trade_prices.c
+++ b/src/empire/trade_prices.c
@@ -50,7 +50,7 @@ static int trade_factor_sell(int land_trader)
         if (policy == TRADE_POLICY_1) {
             percent = trade_get_caravanserai_factor(POLICY_1_BONUS_PERCENT); // trader buy 20% more
         } else if (policy == TRADE_POLICY_2) {
-            percent = - trade_get_caravanserai_factor(POLICY_2_MALUS_PERCENT); // trader buy 10% less
+            percent -= trade_get_caravanserai_factor(POLICY_2_MALUS_PERCENT); // trader buy 10% less
         }
     }
     return percent;
@@ -63,9 +63,9 @@ static int trade_factor_buy(int land_trader)
         int policy = building_monument_module_type(BUILDING_CARAVANSERAI);
 
         if (policy == TRADE_POLICY_1) {
-            percent = - trade_get_caravanserai_factor(POLICY_1_MALUS_PERCENT); // player buy 10% more
+            percent = trade_get_caravanserai_factor(POLICY_1_MALUS_PERCENT); // player buy 10% more
         } else if (policy == TRADE_POLICY_2) {
-            percent = trade_get_caravanserai_factor(POLICY_2_BONUS_PERCENT); // player buy 20% less
+            percent -= trade_get_caravanserai_factor(POLICY_2_BONUS_PERCENT); // player buy 20% less
         }
     }
     return percent;

--- a/src/graphics/color.h
+++ b/src/graphics/color.h
@@ -27,6 +27,8 @@ typedef uint32_t color_t;
 #define COLOR_MASK_NONE 0xffffffff
 #define COLOR_MASK_RED 0xffff0818
 #define COLOR_MASK_GREEN 0xff18ff18
+#define COLOR_MASK_PURPLE 0xff7f0000
+#define COLOR_MASK_DARK_GREEN 0xff005100
 #define COLOR_MASK_BLUE 0x663377ff
 #define COLOR_MASK_GREY 0x66aaaaaa
 #define COLOR_MASK_LEGION_HIGHLIGHT 0x66ff3300

--- a/src/window/trade_prices.c
+++ b/src/window/trade_prices.c
@@ -1,5 +1,8 @@
 #include "trade_prices.h"
 
+#include "building/caravanserai.h"
+#include "building/monument.h"
+#include "city/buildings.h"
 #include "empire/trade_prices.h"
 #include "graphics/graphics.h"
 #include "graphics/image.h"
@@ -20,13 +23,27 @@ static void draw_background(void)
     graphics_shade_rect(17, 53, 622, 334, 0);
     outer_panel_draw(16, 144, 38, 11);
     lang_text_draw(54, 21, 26, 153, FONT_LARGE_BLACK);
-    lang_text_draw(54, 22, 26, 228, FONT_NORMAL_BLACK);
-    lang_text_draw(54, 23, 26, 253, FONT_NORMAL_BLACK);
+    lang_text_draw(54, 22, 26, 226, FONT_NORMAL_BLACK);
+    lang_text_draw(54, 23, 26, 262, FONT_NORMAL_BLACK);
+
     for (int i = 1; i < 16; i++) {
         int image_offset = i + resource_image_offset(i, RESOURCE_IMAGE_ICON);
         image_draw(image_group(GROUP_RESOURCE_ICONS) + image_offset, 126 + 30 * i, 194);
-        text_draw_number_centered(trade_price_buy(i, 0), 120 + 30 * i, 229, 30, FONT_SMALL_PLAIN);
-        text_draw_number_centered(trade_price_sell(i, 0), 120 + 30 * i, 254, 30, FONT_SMALL_PLAIN);
+        text_draw_number_centered(trade_price_buy(i, 0), 120 + 30 * i, 226, 30, FONT_SMALL_PLAIN);
+        text_draw_number_centered(trade_price_sell(i, 0), 120 + 30 * i, 262, 30, FONT_SMALL_PLAIN);
+
+        if (city_buildings_has_caravanserai()) {
+            int policy = building_monument_module_type(BUILDING_CARAVANSERAI);
+            if (policy && policy != TRADE_POLICY_3) {
+                text_draw_number_centered_colored(trade_price_buy(i, 1), 120 + 30 * i, 240, 30, FONT_SMALL_PLAIN, policy == TRADE_POLICY_1 ? COLOR_MASK_PURPLE : COLOR_MASK_DARK_GREEN);
+                text_draw_number_centered_colored(trade_price_sell(i, 1), 120 + 30 * i, 276, 30, FONT_SMALL_PLAIN, policy == TRADE_POLICY_1 ? COLOR_MASK_DARK_GREEN : COLOR_MASK_PURPLE);
+
+                int image_id = image_group(GROUP_EMPIRE_TRADE_ROUTE_TYPE) + 1;
+                image_draw(image_id, 125, 236);
+
+                image_draw(image_id, 125, 272);
+            }
+        }
     }
     lang_text_draw_centered(13, 1, 16, 296, 608, FONT_NORMAL_BLACK);
 


### PR DESCRIPTION
- Adding information of price modification in price advisor window if policy impact prices
- Fix second policy where you purchase 20% more expensive instead of 20% less

![prices](https://user-images.githubusercontent.com/81165266/115630335-24f27c00-a304-11eb-9910-8d2c2d910b80.png)
