### PR TITLE
adding trade policy button in trade advisor window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,6 +597,7 @@ set(WINDOW_FILES
     ${PROJECT_SOURCE_DIR}/src/window/sound_options.c
     ${PROJECT_SOURCE_DIR}/src/window/speed_options.c
     ${PROJECT_SOURCE_DIR}/src/window/trade_opened.c
+    ${PROJECT_SOURCE_DIR}/src/window/trade_policy.c
     ${PROJECT_SOURCE_DIR}/src/window/trade_prices.c
     ${PROJECT_SOURCE_DIR}/src/window/victory_dialog.c
     ${PROJECT_SOURCE_DIR}/src/window/victory_video.c

--- a/src/building/caravanserai.h
+++ b/src/building/caravanserai.h
@@ -3,21 +3,7 @@
 
 #include "building/building.h"
 
-#define TRADE_POLICY_COST 500
 #define MAX_FOOD 1200
-#define POLICY_1_BONUS_PERCENT 20
-#define POLICY_1_MALUS_PERCENT 10
-#define POLICY_2_BONUS_PERCENT 20
-#define POLICY_2_MALUS_PERCENT 10
-#define POLICY_3_BONUS_PERCENT 50
-#define POLICY_3_MALUS_PERCENT 15
-
-typedef enum {
-    NO_POLICY,
-    TRADE_POLICY_1,
-    TRADE_POLICY_2,
-    TRADE_POLICY_3
-} trade_policy;
 
 int building_caravanserai_enough_foods(building *caravanserai);
 int building_caravanserai_get_storage_destination(building *caravanserai);

--- a/src/empire/trade_prices.c
+++ b/src/empire/trade_prices.c
@@ -5,6 +5,7 @@
 #include "city/resource.h"
 #include "core/calc.h"
 #include "trade_prices.h"
+#include "window/trade_policy.h"
 
 struct trade_price {
     int32_t buy;

--- a/src/figuretype/trader.c
+++ b/src/figuretype/trader.c
@@ -33,6 +33,7 @@
 #include "map/routing_path.h"
 #include "scenario/map.h"
 #include "scenario/property.h"
+#include "window/trade_policy.h"
 
 #define INFINITE 10000
 

--- a/src/window/action_popup.c
+++ b/src/window/action_popup.c
@@ -1,7 +1,6 @@
 #include "action_popup.h"
 
 #include "assets/assets.h"
-#include "building/caravanserai.h"
 #include "graphics/generic_button.h"
 #include "graphics/graphics.h"
 #include "graphics/image.h"
@@ -11,6 +10,7 @@
 #include "graphics/window.h"
 #include "input/input.h"
 #include "translation/translation.h"
+#include "window/trade_policy.h"
 
 #define CONFIRM_BUTTON 4
 
@@ -78,6 +78,7 @@ static int init(int title, int prompt, option_menu_item option_1, option_menu_it
 static void draw_background(void)
 {
     window_draw_underlying_window();
+
     graphics_in_dialog();
     outer_panel_draw(80, 40, data.width_blocks, data.height_blocks);
 

--- a/src/window/advisor/trade.c
+++ b/src/window/advisor/trade.c
@@ -1,9 +1,11 @@
 #include "trade.h"
 
+#include "building/caravanserai.h"
+#include "building/monument.h"
+#include "city/buildings.h"
 #include "city/resource.h"
 #include "core/lang.h"
 #include "core/string.h"
-#include "game/resource.h"
 #include "graphics/generic_button.h"
 #include "graphics/graphics.h" 
 #include "graphics/image.h"
@@ -16,6 +18,7 @@
 #include "translation/translation.h"
 #include "window/empire.h"
 #include "window/resource_settings.h"
+#include "window/trade_policy.h"
 #include "window/trade_prices.h"
 
 #define ADVISOR_HEIGHT 27
@@ -28,13 +31,15 @@ static void on_scroll(void);
 
 static void button_prices(int param1, int param2);
 static void button_empire(int param1, int param2);
+static void button_policy(int param1, int param2);
 static void button_resource(int resource_index, int param2);
 
 static scrollbar_type scrollbar = { 580, RESOURCE_Y_OFFSET, RESOURCE_ROW_HEIGHT * MAX_VISIBLE_ROWS, on_scroll, 4 };
 
 static generic_button resource_buttons[] = {
-    {400, 398, 200, 23, button_prices, button_none, 1, 0},
-    {100, 398, 200, 23, button_empire, button_none, 1, 0},
+    {340, 396, 200, 24, button_prices, button_none, 1, 0},
+    {100, 396, 200, 24, button_empire, button_none, 1, 0},
+    {580, 390, 40, 30, button_policy, button_none, 1, 0},
     {64, 56, 480, RESOURCE_ROW_HEIGHT - 2, button_resource, button_none, 0, 0},
     {64, 97, 480, RESOURCE_ROW_HEIGHT - 2, button_resource, button_none, 1, 0},
     {64, 138, 480, RESOURCE_ROW_HEIGHT - 2, button_resource, button_none, 2, 0},
@@ -42,7 +47,7 @@ static generic_button resource_buttons[] = {
     {64, 220, 480, RESOURCE_ROW_HEIGHT - 2, button_resource, button_none, 4, 0},
     {64, 261, 480, RESOURCE_ROW_HEIGHT - 2, button_resource, button_none, 5, 0},
     {64, 302, 480, RESOURCE_ROW_HEIGHT - 2, button_resource, button_none, 6, 0},
-    {64, 343, 480, RESOURCE_ROW_HEIGHT - 2, button_resource, button_none, 7, 0},
+    {64, 343, 480, RESOURCE_ROW_HEIGHT - 2, button_resource, button_none, 7, 0}
 };
 
 static struct {
@@ -143,7 +148,7 @@ static int draw_background(void)
         image_draw(image_id, 32, y_offset + base_y);
         image_draw(image_id, 584 - data.margin_right, y_offset + base_y);
 
-        if (data.focus_button_id - 3 == i) {
+        if (data.focus_button_id - 4 == i) {
             button_border_draw(64, y_offset, 512 - data.margin_right, RESOURCE_ROW_HEIGHT, 1);
         }
         lang_text_draw(23, resource, 72, y_offset + 17, FONT_NORMAL_WHITE);
@@ -164,14 +169,20 @@ static int draw_background(void)
         }
     }
 
-    button_border_draw(398, 396, 200, 24, data.focus_button_id == 1);
-    lang_text_draw_centered(54, 2, 400, 402, 200, FONT_NORMAL_BLACK);
+    button_border_draw(340, 396, 200, 24, data.focus_button_id == 1);
+    lang_text_draw_centered(54, 2, 340, 402, 200, FONT_NORMAL_BLACK);
 
-    button_border_draw(98, 396, 200, 24, data.focus_button_id == 2);
+    button_border_draw(100, 396, 200, 24, data.focus_button_id == 2);
     lang_text_draw_centered(54, 30, 100, 402, 200, FONT_NORMAL_BLACK);
 
     if (data.list->size > MAX_VISIBLE_ROWS) {
         inner_panel_draw(scrollbar.x + 4, scrollbar.y + 28, 2, scrollbar.height / 16 - 3);
+    }
+
+    if (city_buildings_has_caravanserai() && building_monument_working(BUILDING_CARAVANSERAI)) {
+        button_border_draw(580, 390, 40, 30, data.focus_button_id == 3);
+        int image_id = image_group(GROUP_EMPIRE_TRADE_ROUTE_TYPE) + 1;
+        image_draw(image_id, 586, 394);
     }
 
     return ADVISOR_HEIGHT;
@@ -195,7 +206,7 @@ static int handle_mouse(const mouse *m)
         return 1;
     }
     int button_id = data.focus_button_id;
-    int result = generic_buttons_handle_mouse(m, 0, 0, resource_buttons, MAX_VISIBLE_ROWS + 2, &data.focus_button_id);
+    int result = generic_buttons_handle_mouse(m, 0, 0, resource_buttons, MAX_VISIBLE_ROWS + 3, &data.focus_button_id);
     if (button_id != data.focus_button_id) {
         window_request_refresh();
     }
@@ -210,6 +221,13 @@ static void button_prices(int param1, int param2)
 static void button_empire(int param1, int param2)
 {
     window_empire_show();
+}
+
+static void button_policy(int param1, int param2)
+{
+    if (city_buildings_has_caravanserai() && building_monument_working(BUILDING_CARAVANSERAI)) {
+        window_policy_show();
+    }
 }
 
 static void button_resource(int resource_index, int param2)
@@ -242,9 +260,9 @@ static void get_tooltip_text(advisor_tooltip_result *r)
         r->text_id = 106;
     } else if (data.focus_button_id == 2) {
         r->text_id = 41;
-    } else if (data.focus_button_id) {
+    } else if (data.focus_button_id != 3) {
         const mouse *m = mouse_in_dialog(mouse_get());
-        int resource = city_resource_get_potential()->items[data.focus_button_id - 3 + scrollbar.scroll_position];
+        int resource = city_resource_get_potential()->items[data.focus_button_id - 4 + scrollbar.scroll_position];
         if (resource_is_food(resource) && m->x > 180 && m->x < 220) {
             write_resource_storage_tooltip(r, resource);
             return;

--- a/src/window/building/distribution.c
+++ b/src/window/building/distribution.c
@@ -2,20 +2,17 @@
 
 #include "assets/assets.h"
 #include "building/building.h"
-#include "building/caravanserai.h"
 #include "building/dock.h"
 #include "building/market.h"
 #include "building/monument.h"
 #include "building/storage.h"
 #include "building/warehouse.h"
 #include "city/buildings.h"
-#include "city/finance.h"
 #include "city/military.h"
 #include "city/resource.h"
 #include "empire/city.h"
 #include "empire/object.h"
 #include "figure/figure.h"
-#include "game/resource.h"
 #include "graphics/generic_button.h"
 #include "graphics/image.h"
 #include "graphics/lang_text.h"
@@ -24,10 +21,9 @@
 #include "graphics/text.h"
 #include "graphics/window.h"
 #include "scenario/property.h"
-#include "sound/speech.h"
 #include "translation/translation.h"
-#include "window/action_popup.h"
 #include "window/building_info.h"
+#include "window/trade_policy.h"
 
 #include <math.h>
 
@@ -136,21 +132,6 @@ static struct {
     int dock_max_cities_visible;
     int caravanserai_focus_button_id;
 } data;
-
-static const option_menu_item caravanserai_policy_options[3] = {
-        {
-                0, TR_BUILDING_CARAVANSERAI_POLICY_1_TITLE, TR_BUILDING_CARAVANSERAI_POLICY_1,
-                0, "Areldir", "Econ_Logistics", "Trade Policy 1", 0
-        },
-        {
-                0, TR_BUILDING_CARAVANSERAI_POLICY_2_TITLE, TR_BUILDING_CARAVANSERAI_POLICY_2,
-                0, "Areldir", "Econ_Logistics", "Trade Policy 2", 0
-        },
-        {
-                0, TR_BUILDING_CARAVANSERAI_POLICY_3_TITLE, TR_BUILDING_CARAVANSERAI_POLICY_3,
-                0, "Areldir", "Econ_Logistics", "Trade Policy 3", 0
-        }
-};
 
 uint8_t warehouse_full_button_text[] = "32";
 uint8_t warehouse_3quarters_button_text[] = "24";
@@ -1175,57 +1156,14 @@ static void draw_policy_image_border(int x, int y, int focused)
     image_draw(id + 6 + focused, x, y + 5);
 }
 
-void window_building_draw_caravanserai_action(building_info_context *c)
-{
-
-    int policy = building_monument_module_type(BUILDING_CARAVANSERAI);
-    int policy_title = TR_BUILDING_CARAVANSERAI_NO_POLICY;
-
-    if (policy) {
-        policy_title = caravanserai_policy_options[policy - 1].header;
-    }
-
-    text_draw_multiline(translation_for(policy_title), c->x_offset + 160, c->y_offset + 160,
-        260, FONT_NORMAL_BLACK, 0);
-
-    if (policy) {
-        text_draw_multiline(translation_for(policy_title + 1), c->x_offset + 160, c->y_offset + 185,
-            260, FONT_NORMAL_BLACK, 0);
-
-        int policy_image = assets_get_image_id(assets_get_group_id((char *) caravanserai_policy_options[policy - 1].asset_author, (char *) caravanserai_policy_options[policy - 1].asset_name),
-            (char *) caravanserai_policy_options[policy - 1].asset_image_id);
-
-        image_draw(policy_image, c->x_offset + 32, c->y_offset + 150);
-    } else {
-        int policy_image = assets_get_image_id(assets_get_group_id("Areldir", "Econ_Logistics"), "Trade Policy");
-        image_draw(policy_image, c->x_offset + 32, c->y_offset + 150);
-    }
-
-}
-
 void window_building_draw_caravanserai_foreground(building_info_context *c)
 {
     draw_policy_image_border(c->x_offset + 32, c->y_offset + 150, data.caravanserai_focus_button_id == 1);
 }
 
-static void caravanserai_policy(int selection)
+void caravanserai_action(int param1, int param2)
 {
-    if (!selection) {
-        return;
-    }
-
-    sound_speech_play_file("wavs/market4.wav");
-    building *b = building_get(city_buildings_get_caravanserai());
-
-    city_finance_process_construction(TRADE_POLICY_COST);
-    building_monument_add_module(b, selection);
-}
-
-static void caravanserai_action(int param1, int param2)
-{
-    building *b = building_get(city_buildings_get_caravanserai());
-    int current_policy = b->data.monument.upgrades;
-    window_action_popup_show(TR_BUILDING_CARAVANSERAI_POLICY_TITLE, TR_BUILDING_CARAVANSERAI_POLICY_TEXT, caravanserai_policy_options, caravanserai_policy, current_policy);
+    window_policy_show();
 }
 
 void window_building_draw_caravanserai(building_info_context *c)

--- a/src/window/building/figures.c
+++ b/src/window/building/figures.c
@@ -25,6 +25,7 @@
 #include "scenario/property.h"
 #include "translation/translation.h"
 #include "widget/city.h"
+#include "window/trade_policy.h"
 
 #define CAMEL_PORTRAIT 59
 

--- a/src/window/trade_policy.c
+++ b/src/window/trade_policy.c
@@ -1,0 +1,75 @@
+#include "trade_policy.h"
+
+#include "assets/assets.h"
+#include "building/caravanserai.h"
+#include "building/monument.h"
+#include "city/buildings.h"
+#include "city/finance.h"
+#include "graphics/image.h"
+#include "graphics/text.h"
+#include "sound/speech.h"
+#include "translation/translation.h"
+#include "window/action_popup.h"
+
+const option_menu_item caravanserai_policy_options[3] = {
+        {
+                0, TR_BUILDING_CARAVANSERAI_POLICY_1_TITLE, TR_BUILDING_CARAVANSERAI_POLICY_1,
+                0, "Areldir", "Econ_Logistics", "Trade Policy 1", 0
+        },
+        {
+                0, TR_BUILDING_CARAVANSERAI_POLICY_2_TITLE, TR_BUILDING_CARAVANSERAI_POLICY_2,
+                0, "Areldir", "Econ_Logistics", "Trade Policy 2", 0
+        },
+        {
+                0, TR_BUILDING_CARAVANSERAI_POLICY_3_TITLE, TR_BUILDING_CARAVANSERAI_POLICY_3,
+                0, "Areldir", "Econ_Logistics", "Trade Policy 3", 0
+        }
+};
+
+void window_building_draw_caravanserai_action(building_info_context *c)
+{
+
+    int policy = building_monument_module_type(BUILDING_CARAVANSERAI);
+    int policy_title = TR_BUILDING_CARAVANSERAI_NO_POLICY;
+
+    if (policy) {
+        policy_title = caravanserai_policy_options[policy - 1].header;
+    }
+
+    text_draw_multiline(translation_for(policy_title), c->x_offset + 160, c->y_offset + 160,
+                        260, FONT_NORMAL_BLACK, 0);
+
+    if (policy) {
+        text_draw_multiline(translation_for(policy_title + 1), c->x_offset + 160, c->y_offset + 185,
+                            260, FONT_NORMAL_BLACK, 0);
+
+        int policy_image = assets_get_image_id(assets_get_group_id((char *) caravanserai_policy_options[policy - 1].asset_author, (char *) caravanserai_policy_options[policy - 1].asset_name),
+                                               (char *) caravanserai_policy_options[policy - 1].asset_image_id);
+
+        image_draw(policy_image, c->x_offset + 32, c->y_offset + 150);
+    } else {
+        int policy_image = assets_get_image_id(assets_get_group_id("Areldir", "Econ_Logistics"), "Trade Policy");
+        image_draw(policy_image, c->x_offset + 32, c->y_offset + 150);
+    }
+}
+
+static void caravanserai_policy(int selection)
+{
+    if (!selection) {
+        return;
+    }
+
+    sound_speech_play_file("wavs/market4.wav");
+    building *b = building_get(city_buildings_get_caravanserai());
+
+    city_finance_process_construction(TRADE_POLICY_COST);
+    building_monument_add_module(b, selection);
+}
+
+void window_policy_show()
+{
+    building *b = building_get(city_buildings_get_caravanserai());
+    int current_policy = b->data.monument.upgrades;
+    window_action_popup_show(TR_BUILDING_CARAVANSERAI_POLICY_TITLE, TR_BUILDING_CARAVANSERAI_POLICY_TEXT,
+                             caravanserai_policy_options, caravanserai_policy, current_policy);
+}

--- a/src/window/trade_policy.h
+++ b/src/window/trade_policy.h
@@ -1,0 +1,24 @@
+#ifndef WINDOW_TRADE_POLICY_H
+#define WINDOW_TRADE_POLICY_H
+
+#include "building/common.h"
+
+#define TRADE_POLICY_COST 500
+#define POLICY_1_BONUS_PERCENT 20
+#define POLICY_1_MALUS_PERCENT 10
+#define POLICY_2_BONUS_PERCENT 20
+#define POLICY_2_MALUS_PERCENT 10
+#define POLICY_3_BONUS_PERCENT 50
+#define POLICY_3_MALUS_PERCENT 15
+
+typedef enum {
+    NO_POLICY,
+    TRADE_POLICY_1,
+    TRADE_POLICY_2,
+    TRADE_POLICY_3
+} trade_policy;
+
+void window_building_draw_caravanserai_action(building_info_context *c);
+void window_policy_show();
+
+#endif //WINDOW_TRADE_POLICY_H

--- a/src/window/trade_prices.c
+++ b/src/window/trade_prices.c
@@ -13,6 +13,7 @@
 #include "graphics/window.h"
 #include "input/input.h"
 #include "window/advisors.h"
+#include "window/trade_policy.h"
 
 static void draw_background(void)
 {


### PR DESCRIPTION
- Adding trade policy access in trade advisor window
- Available only if caravanserai is ready
- move trade popup from distribution.c to caravanserai.c to centralize code

![policy_advisor](https://user-images.githubusercontent.com/81165266/115796149-9cdaa800-a3d1-11eb-93fd-e1dc39c500eb.png)
