### PR TITLE
Always stop stockpiled when send request + stockpiled icon instead of…

### DIFF
--- a/src/city/request.c
+++ b/src/city/request.c
@@ -46,3 +46,13 @@ int city_request_get_status(int index)
     }
     return 0;
 }
+
+int city_get_request_resource(int index) {
+    int num_requests = 0;
+    if (city_request_has_troop_request()) {
+        num_requests = 1;
+    }
+    const scenario_request *request = scenario_request_get_visible(index - num_requests);
+
+    return request->resource;
+}

--- a/src/city/request.h
+++ b/src/city/request.h
@@ -14,5 +14,6 @@ enum {
 
 int city_request_has_troop_request(void);
 int city_request_get_status(int index);
+int city_get_request_resource(int index);
 
 #endif // CITY_REQUEST_H

--- a/src/window/advisor/imperial.c
+++ b/src/window/advisor/imperial.c
@@ -207,6 +207,8 @@ static void confirm_send_goods(int accepted)
 void button_request(int index, int param2)
 {
     int status = city_request_get_status(index);
+    int resource_type = city_get_request_resource(index);
+
     if (status) {
         city_military_clear_empire_service_legions();
         switch (status) {
@@ -223,6 +225,11 @@ void button_request(int index, int param2)
                 window_popup_dialog_show(POPUP_DIALOG_NOT_ENOUGH_GOODS, confirm_nothing, 0);
                 break;
             default:
+                if (resource_type != RESOURCE_DENARII) {
+                    if (city_resource_is_stockpiled(resource_type)) {
+                        city_resource_toggle_stockpiled(resource_type);
+                    }
+                }
                 selected_request_id = (status - CITY_REQUEST_STATUS_MAX) & ~CITY_REQUEST_STATUS_RESOURCES_FROM_GRANARY;
                 if (status & CITY_REQUEST_STATUS_RESOURCES_FROM_GRANARY) {
                     window_popup_dialog_show_custom_text(

--- a/src/window/advisor/trade.c
+++ b/src/window/advisor/trade.c
@@ -70,7 +70,11 @@ static void draw_resource_status_text(int resource, int x, int y, int box_width)
     if (empire_can_export_resource_potentially(resource)) {
         trade_flags_potential |= TRADE_STATUS_EXPORT;
     }
+
     if (trade_flags_potential == TRADE_STATUS_NONE) {
+        if (city_resource_is_stockpiled(resource)) {
+            lang_text_draw_centered(54, 3, x, y + 10, box_width, FONT_NORMAL_RED);
+        }
         return;
     }
 
@@ -84,7 +88,7 @@ static void draw_resource_status_text(int resource, int x, int y, int box_width)
     resource_trade_status trade_status = city_resource_trade_status(resource);
 
     int two_lines = trade_flags_potential == TRADE_STATUS_IMPORT_EXPORT ||
-        (trade_flags_potential & TRADE_STATUS_IMPORT && city_resource_is_stockpiled(resource));
+                    (trade_flags_potential & TRADE_STATUS_IMPORT && city_resource_is_stockpiled(resource));
 
     if (!two_lines) {
         y += 10;


### PR DESCRIPTION
- Always stop stockpiled resource when send request (added in imperial advisor window)
- remove is storage text which are only available if !TRADE_STATUS_NONE
- replace by icon near resource image like in sidebar

![stockpiled_icon](https://user-images.githubusercontent.com/81165266/115900975-e58d7200-a460-11eb-91e4-6e3803897259.png)
