### PR TITLE
Improve pathfinding performance:

### DIFF
--- a/src/core/calc.c
+++ b/src/core/calc.c
@@ -1,7 +1,5 @@
 #include "core/calc.h"
 
-#define FAST_INT_HYPOTENUSE(long_edge, short_edge) 235 * ((long_edge) + ((short_edge) >> 1)) >> 8
-
 int calc_adjust_with_percentage(int value, int percentage)
 {
     return percentage * value / 100;
@@ -35,11 +33,7 @@ int calc_maximum_distance(int x1, int y1, int x2, int y2)
 {
     int distance_x = get_delta(x1, x2);
     int distance_y = get_delta(y1, y2);
-    if (distance_x >= distance_y) {
-        return FAST_INT_HYPOTENUSE(distance_x, distance_y);
-    } else {
-        return FAST_INT_HYPOTENUSE(distance_y, distance_x);
-    }
+    return distance_x > distance_y ? distance_x : distance_y;
 }
 
 direction_type calc_general_direction(int x_from, int y_from, int x_to, int y_to)

--- a/src/map/routing.c
+++ b/src/map/routing.c
@@ -1,6 +1,7 @@
 #include "routing.h"
 
 #include "building/building.h"
+#include "core/time.h"
 #include "map/building.h"
 #include "map/figure.h"
 #include "map/grid.h"
@@ -8,17 +9,31 @@
 #include "map/routing_data.h"
 #include "map/terrain.h"
 
+#include <stdlib.h>
+
 #define MAX_QUEUE GRID_SIZE * GRID_SIZE
 #define GUARD 50000
 
-static const int ROUTE_OFFSETS[] = {-162, 1, 162, -1, -161, 163, 161, -163};
+typedef enum {
+    DIRECTIONS_NO_DIAGONALS = 4,
+    DIRECTIONS_DIAGONALS = 8
+} max_directions;
 
-static grid_i16 routing_distance;
+static const int ROUTE_OFFSETS[] = { -162, 1, 162, -1, -161, 163, 161, -163 };
+static const int ROUTE_OFFSETS_X[] = { 0, 1, 0, -1,  1, 1, -1, -1 };
+static const int ROUTE_OFFSETS_Y[] = { -1, 0, 1,  0, -1, 1,  1, -1 };
+
+static struct {
+    grid_i16 possible;
+    grid_i16 determined;
+    int dst_x;
+    int dst_y;
+} distance;
 
 static struct {
     int total_routes_calculated;
     int enemy_routes_calculated;
-} stats = {0, 0};
+} stats;
 
 static struct {
     int head;
@@ -29,214 +44,263 @@ static struct {
 static grid_u8 water_drag;
 
 static struct {
+    grid_u8 status;
+    time_millis last_check;
+} fighting_data;
+
+static struct {
     int through_building_id;
 } state;
 
-static void clear_distances(void)
+static void reset_fighting_status(void)
 {
-    map_grid_clear_i16(routing_distance.items);
+    time_millis current_time = time_get_millis();
+    if (current_time != fighting_data.last_check) {
+        map_grid_clear_u8(fighting_data.status.items);
+        fighting_data.last_check = current_time;
+    }
 }
 
-static void enqueue(int next_offset, int dist)
+static void clear_data(void)
 {
-    routing_distance.items[next_offset] = dist;
+    reset_fighting_status();
+    map_grid_clear_i16(distance.possible.items);
+    map_grid_clear_i16(distance.determined.items);
+    queue.head = 0;
+    queue.tail = 0;
+}
+
+static inline void enqueue(int next_offset, int dist)
+{
+    distance.determined.items[next_offset] = dist;
     queue.items[queue.tail++] = next_offset;
     if (queue.tail >= MAX_QUEUE) {
         queue.tail = 0;
     }
 }
 
-static int valid_offset(int grid_offset)
+static inline int queue_pop(void)
 {
-    return map_grid_is_valid_offset(grid_offset) && routing_distance.items[grid_offset] == 0;
+    int result = queue.items[queue.head];
+    if (++queue.head >= MAX_QUEUE) {
+        queue.head = 0;
+    }
+    return result;
 }
 
-static void route_queue(int source, int dest, void (*callback)(int next_offset, int dist))
+static inline int ordered_queue_parent(int index)
 {
-    clear_distances();
-    queue.head = queue.tail = 0;
-    enqueue(source, 1);
-    while (queue.head != queue.tail) {
-        int offset = queue.items[queue.head];
-        if (offset == dest) {
-            break;
-        }
-        int dist = 1 + routing_distance.items[offset];
-        for (int i = 0; i < 4; i++) {
-            if (valid_offset(offset + ROUTE_OFFSETS[i])) {
-                callback(offset + ROUTE_OFFSETS[i], dist);
-            }
-        }
-        if (++queue.head >= MAX_QUEUE) {
-            queue.head = 0;
-        }
+    return (index - 1) / 2;
+}
+
+static inline void ordered_queue_swap(int first, int second)
+{
+    int temp = queue.items[first];
+    queue.items[first] = queue.items[second];
+    queue.items[second] = temp;
+}
+
+void ordered_queue_reorder(int start_index)
+{
+    int left_child = 2 * start_index + 1;
+    if (left_child >= queue.tail) {
+        return;
+    }
+    int right_child = left_child + 1;
+    int smallest = start_index;
+    int16_t *offset_smallest = &distance.possible.items[queue.items[smallest]];
+    if (distance.possible.items[queue.items[left_child]] < *offset_smallest) {
+        smallest = left_child;
+        offset_smallest = &distance.possible.items[queue.items[smallest]];
+    }
+    if (right_child < queue.tail &&
+        distance.possible.items[queue.items[right_child]] < *offset_smallest) {
+        smallest = right_child;
+    }
+    if (smallest != start_index) {
+        ordered_queue_swap(start_index, smallest);
+        ordered_queue_reorder(smallest);
     }
 }
 
-static void route_queue_until(int source, int (*callback)(int next_offset, int dist))
+static inline int ordered_queue_pop(void)
 {
-    clear_distances();
-    queue.head = queue.tail = 0;
-    enqueue(source, 1);
-    while (queue.head != queue.tail) {
-        int offset = queue.items[queue.head];
-        int dist = 1 + routing_distance.items[offset];
-        for (int i = 0; i < 4; i++) {
-            if (valid_offset(offset + ROUTE_OFFSETS[i])) {
-                if (!callback(offset + ROUTE_OFFSETS[i], dist)) {
+    int min = queue.items[0];
+    queue.items[0] = queue.items[--queue.tail];
+    ordered_queue_reorder(0);
+    return min;
+}
+
+static inline void ordered_queue_reduce_index(int index, int offset, int dist)
+{
+    queue.items[index] = offset;
+    while (index && distance.possible.items[queue.items[ordered_queue_parent(index)]] > dist) {
+        ordered_queue_swap(index, ordered_queue_parent(index));
+        index = ordered_queue_parent(index);
+    }
+}
+
+static void ordered_enqueue(int next_offset, int current_dist, int remaining_dist)
+{
+    int possible_dist = remaining_dist + current_dist;
+    int index = queue.tail;
+    if (distance.possible.items[next_offset]) {
+        if (distance.possible.items[next_offset] <= possible_dist) {
+            return;
+        } else {
+            for (int i = 0; i < queue.tail; i++) {
+                if (queue.items[i] == next_offset) {
+                    index = i;
                     break;
                 }
             }
         }
-        if (++queue.head >= MAX_QUEUE) {
-            queue.head = 0;
-        }
+    } else {
+        queue.tail++;
     }
+    distance.determined.items[next_offset] = current_dist;
+    distance.possible.items[next_offset] = possible_dist;
+
+    ordered_queue_reduce_index(index, next_offset, possible_dist);
 }
 
-static void route_queue_max(int source, int dest, int max_tiles, void (*callback)(int, int))
+static inline int valid_offset(int grid_offset)
 {
-    clear_distances();
-    queue.head = queue.tail = 0;
-    enqueue(source, 1);
+    return map_grid_is_valid_offset(grid_offset) && distance.determined.items[grid_offset] == 0;
+}
+
+static inline int distance_left(int x, int y)
+{
+    return abs(distance.dst_x - x) + abs(distance.dst_y - y);
+}
+
+static void route_queue_from_to(int src_x, int src_y, int dst_x, int dst_y, int max_tiles,
+    void (*callback)(int next_offset, int dist, int remaining_dist))
+{
+    clear_data();
+    distance.dst_x = dst_x;
+    distance.dst_y = dst_y;
+    int dest = map_grid_offset(dst_x, dst_y);
+    ordered_enqueue(map_grid_offset(src_x, src_y), 1, 0);
     int tiles = 0;
-    while (queue.head != queue.tail) {
-        int offset = queue.items[queue.head];
-        if (offset == dest || ++tiles > max_tiles) {
+    while (queue.tail) {
+        int offset = ordered_queue_pop();
+        if (offset == dest || (max_tiles && ++tiles > max_tiles)) {
             break;
         }
-        int dist = 1 + routing_distance.items[offset];
+        int x = map_grid_offset_to_x(offset);
+        int y = map_grid_offset_to_y(offset);
+        int dist = 1 + distance.determined.items[offset];
+        distance.possible.items[offset] = 1;
         for (int i = 0; i < 4; i++) {
             if (valid_offset(offset + ROUTE_OFFSETS[i])) {
-                callback(offset + ROUTE_OFFSETS[i], dist);
+                callback(offset + ROUTE_OFFSETS[i], dist,
+                    distance_left(x + ROUTE_OFFSETS_X[i], y + ROUTE_OFFSETS_Y[i]));
             }
-        }
-        if (++queue.head >= MAX_QUEUE) {
-            queue.head = 0;
         }
     }
 }
 
-static void route_queue_boat(int source, void (*callback)(int, int))
+static void route_queue_all_from(int source, max_directions directions, int (*callback)(int next_offset, int dist), int is_boat)
 {
-    clear_distances();
+    clear_data();
     map_grid_clear_u8(water_drag.items);
-    queue.head = queue.tail = 0;
     enqueue(source, 1);
     int tiles = 0;
     while (queue.head != queue.tail) {
-        int offset = queue.items[queue.head];
         if (++tiles > GUARD) {
             break;
         }
-        int drag = terrain_water.items[offset] == WATER_N2_MAP_EDGE ? 4 : 0;
-        if (drag && water_drag.items[offset]++ < drag) {
+        int offset = queue_pop();
+        int drag = is_boat && terrain_water.items[offset] == WATER_N2_MAP_EDGE ? 4 : 0;
+        if (water_drag.items[offset] < drag) {
+            water_drag.items[offset]++;
             queue.items[queue.tail++] = offset;
             if (queue.tail >= MAX_QUEUE) {
                 queue.tail = 0;
             }
         } else {
-            int dist = 1 + routing_distance.items[offset];
-            for (int i = 0; i < 4; i++) {
+            int dist = 1 + distance.determined.items[offset];
+            for (int i = 0; i < directions; i++) {
                 if (valid_offset(offset + ROUTE_OFFSETS[i])) {
-                    callback(offset + ROUTE_OFFSETS[i], dist);
+                    if (!callback(offset + ROUTE_OFFSETS[i], dist)) {
+                        break;
+                    }
                 }
             }
         }
-        if (++queue.head >= MAX_QUEUE) {
-            queue.head = 0;
-        }
     }
 }
 
-static void route_queue_dir8(int source, void (*callback)(int, int))
-{
-    clear_distances();
-    queue.head = queue.tail = 0;
-    enqueue(source, 1);
-    int tiles = 0;
-    while (queue.head != queue.tail) {
-        if (++tiles > GUARD) {
-            break;
-        }
-        int offset = queue.items[queue.head];
-        int dist = 1 + routing_distance.items[offset];
-        for (int i = 0; i < 8; i++) {
-            if (valid_offset(offset + ROUTE_OFFSETS[i])) {
-                callback(offset + ROUTE_OFFSETS[i], dist);
-            }
-        }
-        if (++queue.head >= MAX_QUEUE) {
-            queue.head = 0;
-        }
-    }
-}
-
-static void callback_calc_distance(int next_offset, int dist)
+static int callback_calc_distance(int next_offset, int dist)
 {
     if (terrain_land_citizen.items[next_offset] >= CITIZEN_0_ROAD) {
         enqueue(next_offset, dist);
     }
+    return 1;
 }
 
 void map_routing_calculate_distances(int x, int y)
 {
     ++stats.total_routes_calculated;
-    route_queue(map_grid_offset(x, y), -1, callback_calc_distance);
+    route_queue_all_from(map_grid_offset(x, y), DIRECTIONS_NO_DIAGONALS, callback_calc_distance, 0);
 }
 
-static void callback_calc_distance_water_boat(int next_offset, int dist)
+static int callback_calc_distance_water_boat(int next_offset, int dist)
 {
     if (terrain_water.items[next_offset] != WATER_N1_BLOCKED &&
         terrain_water.items[next_offset] != WATER_N3_LOW_BRIDGE) {
         enqueue(next_offset, dist);
         if (terrain_water.items[next_offset] == WATER_N2_MAP_EDGE) {
-            routing_distance.items[next_offset] += 4;
+            distance.determined.items[next_offset] += 4;
         }
     }
+    return 1;
 }
 
 void map_routing_calculate_distances_water_boat(int x, int y)
 {
     int grid_offset = map_grid_offset(x, y);
     if (terrain_water.items[grid_offset] == WATER_N1_BLOCKED) {
-        clear_distances();
+        clear_data();
     } else {
-        route_queue_boat(grid_offset, callback_calc_distance_water_boat);
+        route_queue_all_from(grid_offset, DIRECTIONS_NO_DIAGONALS, callback_calc_distance_water_boat, 1);
     }
 }
 
-static void callback_calc_distance_water_flotsam(int next_offset, int dist)
+static int callback_calc_distance_water_flotsam(int next_offset, int dist)
 {
     if (terrain_water.items[next_offset] != WATER_N1_BLOCKED) {
         enqueue(next_offset, dist);
     }
+    return 1;
 }
 
 void map_routing_calculate_distances_water_flotsam(int x, int y)
 {
     int grid_offset = map_grid_offset(x, y);
     if (terrain_water.items[grid_offset] == WATER_N1_BLOCKED) {
-        clear_distances();
+        clear_data();
     } else {
-        route_queue_dir8(grid_offset, callback_calc_distance_water_flotsam);
+        route_queue_all_from(grid_offset, DIRECTIONS_DIAGONALS, callback_calc_distance_water_flotsam, 0);
     }
 }
 
-static void callback_calc_distance_build_wall(int next_offset, int dist)
+static int callback_calc_distance_build_wall(int next_offset, int dist)
 {
     if (terrain_land_citizen.items[next_offset] == CITIZEN_4_CLEAR_TERRAIN) {
         enqueue(next_offset, dist);
     }
+    return 1;
 }
 
-static void callback_calc_distance_build_road(int next_offset, int dist)
+static int callback_calc_distance_build_road(int next_offset, int dist)
 {
     int blocked = 0;
     switch (terrain_land_citizen.items[next_offset]) {
         case CITIZEN_N3_AQUEDUCT:
             if (!map_can_place_road_under_aqueduct(next_offset)) {
-                routing_distance.items[next_offset] = -1;
+                distance.determined.items[next_offset] = -1;
                 blocked = 1;
             }
             break;
@@ -253,9 +317,10 @@ static void callback_calc_distance_build_road(int next_offset, int dist)
     if (!blocked) {
         enqueue(next_offset, dist);
     }
+    return 1;
 }
 
-static void callback_calc_distance_build_aqueduct(int next_offset, int dist)
+static int callback_calc_distance_build_aqueduct(int next_offset, int dist)
 {
     int blocked = 0;
     switch (terrain_land_citizen.items[next_offset]) {
@@ -273,12 +338,13 @@ static void callback_calc_distance_build_aqueduct(int next_offset, int dist)
             break;
     }
     if (map_terrain_is(next_offset, TERRAIN_ROAD) && !map_can_place_aqueduct_on_road(next_offset)) {
-        routing_distance.items[next_offset] = -1;
+        distance.determined.items[next_offset] = -1;
         blocked = 1;
     }
     if (!blocked) {
         enqueue(next_offset, dist);
     }
+    return 1;
 }
 
 static int map_can_place_initial_road_or_aqueduct(int grid_offset, int is_aqueduct)
@@ -318,10 +384,10 @@ static int map_can_place_initial_road_or_aqueduct(int grid_offset, int is_aquedu
 int map_routing_calculate_distances_for_building(routed_building_type type, int x, int y)
 {
     if (type == ROUTED_BUILDING_WALL) {
-        route_queue(map_grid_offset(x, y), -1, callback_calc_distance_build_wall);
+        route_queue_all_from(map_grid_offset(x, y), DIRECTIONS_NO_DIAGONALS, callback_calc_distance_build_wall, 0);
         return 1;
     }
-    clear_distances();
+    clear_data();
     int source_offset = map_grid_offset(x, y);
     if (!map_can_place_initial_road_or_aqueduct(source_offset, type != ROUTED_BUILDING_ROAD)) {
         return 0;
@@ -332,9 +398,9 @@ int map_routing_calculate_distances_for_building(routed_building_type type, int 
     }
     ++stats.total_routes_calculated;
     if (type == ROUTED_BUILDING_ROAD) {
-        route_queue(source_offset, -1, callback_calc_distance_build_road);
+        route_queue_all_from(source_offset, DIRECTIONS_NO_DIAGONALS, callback_calc_distance_build_road, 0);
     } else {
-        route_queue(source_offset, -1, callback_calc_distance_build_aqueduct);
+        route_queue_all_from(source_offset, DIRECTIONS_NO_DIAGONALS, callback_calc_distance_build_aqueduct, 0);
     }
     return 1;
 }
@@ -355,7 +421,7 @@ static int callback_delete_wall_aqueduct(int next_offset, int dist)
 void map_routing_delete_first_wall_or_aqueduct(int x, int y)
 {
     ++stats.total_routes_calculated;
-    route_queue_until(map_grid_offset(x, y), callback_delete_wall_aqueduct);
+    route_queue_all_from(map_grid_offset(x, y), DIRECTIONS_NO_DIAGONALS, callback_delete_wall_aqueduct, 0);
 }
 
 static int is_fighting_friendly(figure *f)
@@ -363,9 +429,12 @@ static int is_fighting_friendly(figure *f)
     return f->is_friendly && f->action_state == FIGURE_ACTION_150_ATTACK;
 }
 
-static int has_fighting_friendly(int grid_offset)
+static inline int has_fighting_friendly(int grid_offset)
 {
-    return map_figure_foreach_until(grid_offset, is_fighting_friendly);
+    if (!(fighting_data.status.items[grid_offset] & 0x80)) {
+        fighting_data.status.items[grid_offset] |= 0x80 | map_figure_foreach_until(grid_offset, is_fighting_friendly);
+    }
+    return fighting_data.status.items[grid_offset] & 1;
 }
 
 static int is_fighting_enemy(figure *f)
@@ -373,79 +442,81 @@ static int is_fighting_enemy(figure *f)
     return !f->is_friendly && f->action_state == FIGURE_ACTION_150_ATTACK;
 }
 
-static int has_fighting_enemy(int grid_offset)
+static inline int has_fighting_enemy(int grid_offset)
 {
-    return map_figure_foreach_until(grid_offset, is_fighting_enemy);
+    if (!(fighting_data.status.items[grid_offset] & 0x40)) {
+        fighting_data.status.items[grid_offset] |= 0x40 | (map_figure_foreach_until(grid_offset, is_fighting_enemy) << 1);
+    }
+    return fighting_data.status.items[grid_offset] & 2;
 }
 
-static void callback_travel_citizen_land(int next_offset, int dist)
+static void callback_travel_citizen_land(int next_offset, int dist, int remaining_dist)
 {
     if (terrain_land_citizen.items[next_offset] >= 0 && !has_fighting_friendly(next_offset)) {
-        enqueue(next_offset, dist);
+        ordered_enqueue(next_offset, dist, remaining_dist);
     }
 }
 
 int map_routing_citizen_can_travel_over_land(int src_x, int src_y, int dst_x, int dst_y)
 {
-    int src_offset = map_grid_offset(src_x, src_y);
-    int dst_offset = map_grid_offset(dst_x, dst_y);
     ++stats.total_routes_calculated;
-    route_queue(src_offset, dst_offset, callback_travel_citizen_land);
-    return routing_distance.items[dst_offset] != 0;
+    route_queue_from_to(src_x, src_y, dst_x, dst_y, 0, callback_travel_citizen_land);
+    return distance.determined.items[map_grid_offset(dst_x, dst_y)] != 0;
 }
 
-static void callback_travel_citizen_road_garden(int next_offset, int dist)
+static void callback_travel_citizen_road_garden(int next_offset, int dist, int remaining_dist)
 {
     if (terrain_land_citizen.items[next_offset] >= CITIZEN_0_ROAD &&
         terrain_land_citizen.items[next_offset] <= CITIZEN_2_PASSABLE_TERRAIN) {
-        enqueue(next_offset, dist);
+        ordered_enqueue(next_offset, dist, remaining_dist);
     }
 }
 
 int map_routing_citizen_can_travel_over_road_garden(int src_x, int src_y, int dst_x, int dst_y)
 {
-    int src_offset = map_grid_offset(src_x, src_y);
     int dst_offset = map_grid_offset(dst_x, dst_y);
+    if (terrain_land_citizen.items[dst_offset] < CITIZEN_0_ROAD ||
+        terrain_land_citizen.items[dst_offset] > CITIZEN_2_PASSABLE_TERRAIN) {
+        return 0;
+    }
     ++stats.total_routes_calculated;
-    route_queue(src_offset, dst_offset, callback_travel_citizen_road_garden);
-    return routing_distance.items[dst_offset] != 0;
+    route_queue_from_to(src_x, src_y, dst_x, dst_y, 0, callback_travel_citizen_road_garden);
+    return distance.determined.items[dst_offset] != 0;
 }
 
-static void callback_travel_walls(int next_offset, int dist)
+static void callback_travel_walls(int next_offset, int dist, int remaining_dist)
 {
     if (terrain_walls.items[next_offset] >= WALL_0_PASSABLE &&
         terrain_walls.items[next_offset] <= 2) {
-        enqueue(next_offset, dist);
+        ordered_enqueue(next_offset, dist, remaining_dist);
     }
 }
 
 int map_routing_can_travel_over_walls(int src_x, int src_y, int dst_x, int dst_y)
 {
-    int src_offset = map_grid_offset(src_x, src_y);
-    int dst_offset = map_grid_offset(dst_x, dst_y);
     ++stats.total_routes_calculated;
-    route_queue(src_offset, dst_offset, callback_travel_walls);
-    return routing_distance.items[dst_offset] != 0;
+    route_queue_from_to(src_x, src_y, dst_x, dst_y, 0, callback_travel_walls);
+    return distance.determined.items[map_grid_offset(dst_x, dst_y)] != 0;
 }
 
-static void callback_travel_noncitizen_land_through_building(int next_offset, int dist)
+static void callback_travel_noncitizen_land_through_building(int next_offset, int dist, int remaining_dist)
 {
     if (!has_fighting_enemy(next_offset)) {
         if (terrain_land_noncitizen.items[next_offset] == NONCITIZEN_0_PASSABLE ||
             terrain_land_noncitizen.items[next_offset] == NONCITIZEN_2_CLEARABLE ||
             (terrain_land_noncitizen.items[next_offset] == NONCITIZEN_1_BUILDING &&
-                map_building_at(next_offset) == state.through_building_id)) {
-            enqueue(next_offset, dist);
+            map_building_at(next_offset) == state.through_building_id)) {
+            ordered_enqueue(next_offset, dist, remaining_dist);
         }
     }
 }
 
-static void callback_travel_noncitizen_land(int next_offset, int dist)
+static void callback_travel_noncitizen_land(int next_offset, int dist, int remaining_dist)
 {
     if (!has_fighting_enemy(next_offset)) {
         if (terrain_land_noncitizen.items[next_offset] >= NONCITIZEN_0_PASSABLE &&
             terrain_land_noncitizen.items[next_offset] < NONCITIZEN_5_FORT) {
-            enqueue(next_offset, dist);
+            ordered_enqueue(next_offset, dist, remaining_dist);
         }
     }
 }
@@ -453,33 +524,29 @@ static void callback_travel_noncitizen_land(int next_offset, int dist)
 int map_routing_noncitizen_can_travel_over_land(
     int src_x, int src_y, int dst_x, int dst_y, int only_through_building_id, int max_tiles)
 {
-    int src_offset = map_grid_offset(src_x, src_y);
-    int dst_offset = map_grid_offset(dst_x, dst_y);
     ++stats.total_routes_calculated;
     ++stats.enemy_routes_calculated;
     if (only_through_building_id) {
         state.through_building_id = only_through_building_id;
-        route_queue(src_offset, dst_offset, callback_travel_noncitizen_land_through_building);
+        route_queue_from_to(src_x, src_y, dst_x, dst_y, 0, callback_travel_noncitizen_land_through_building);
     } else {
-        route_queue_max(src_offset, dst_offset, max_tiles, callback_travel_noncitizen_land);
+        route_queue_from_to(src_x, src_y, dst_x, dst_y, max_tiles, callback_travel_noncitizen_land);
     }
-    return routing_distance.items[dst_offset] != 0;
+    return distance.determined.items[map_grid_offset(dst_x, dst_y)] != 0;
 }
 
-static void callback_travel_noncitizen_through_everything(int next_offset, int dist)
+static void callback_travel_noncitizen_through_everything(int next_offset, int dist, int remaining_dist)
 {
     if (terrain_land_noncitizen.items[next_offset] >= NONCITIZEN_0_PASSABLE) {
-        enqueue(next_offset, dist);
+        ordered_enqueue(next_offset, dist, remaining_dist);
     }
 }
 
 int map_routing_noncitizen_can_travel_through_everything(int src_x, int src_y, int dst_x, int dst_y)
 {
-    int src_offset = map_grid_offset(src_x, src_y);
-    int dst_offset = map_grid_offset(dst_x, dst_y);
     ++stats.total_routes_calculated;
-    route_queue(src_offset, dst_offset, callback_travel_noncitizen_through_everything);
-    return routing_distance.items[dst_offset] != 0;
+    route_queue_from_to(src_x, src_y, dst_x, dst_y, 0, callback_travel_noncitizen_through_everything);
+    return distance.determined.items[map_grid_offset(dst_x, dst_y)] != 0;
 }
 
 void map_routing_block(int x, int y, int size)
@@ -489,14 +556,14 @@ void map_routing_block(int x, int y, int size)
     }
     for (int dy = 0; dy < size; dy++) {
         for (int dx = 0; dx < size; dx++) {
-            routing_distance.items[map_grid_offset(x+dx, y+dy)] = 0;
+            distance.determined.items[map_grid_offset(x + dx, y + dy)] = 0;
         }
     }
 }
 
 int map_routing_distance(int grid_offset)
 {
-    return routing_distance.items[grid_offset];
+    return distance.determined.items[grid_offset];
 }
 
 void map_routing_save_state(buffer *buf)


### PR DESCRIPTION
- Aggressively cache values that take long to find but aren't updated very often
- Implement the A* pathfinding algorithm (instead of Djikstra's) when there's a source and destination (Djikstra's algorithm is more efficient when calculating all the distances from a single tile)
-  This not only improves performance on lower end hardware (I.e. Vita) but also may help in the future select the closest building with more accuracy. 