### PR TITLE
Locale-specific separators for large numbers

### DIFF
--- a/src/core/locale.c
+++ b/src/core/locale.c
@@ -128,3 +128,29 @@ int locale_translate_rank_autosaves(void)
             return 0;
     }
 }
+
+uint8_t locale_number_thousands_separator(void)
+{
+    switch (data.last_determined_language) {
+        case LANGUAGE_ENGLISH:
+            return ',';
+    
+        case LANGUAGE_ITALIAN:
+        case LANGUAGE_PORTUGUESE:
+        case LANGUAGE_SPANISH:
+            return '.';
+
+        case LANGUAGE_GERMAN:
+        case LANGUAGE_SWEDISH:
+        case LANGUAGE_POLISH:
+        case LANGUAGE_FRENCH:
+        case LANGUAGE_RUSSIAN:
+        case LANGUAGE_KOREAN:
+        case LANGUAGE_TRADITIONAL_CHINESE:
+        case LANGUAGE_SIMPLIFIED_CHINESE:
+            return ' ';
+
+        default:
+            return 0;
+    }
+}

--- a/src/core/locale.h
+++ b/src/core/locale.h
@@ -1,6 +1,8 @@
 #ifndef CORE_LOCALE_H
 #define CORE_LOCALE_H
 
+#include <stdint.h>
+
 /**
  * Language type
  */
@@ -46,5 +48,11 @@ int locale_translate_money_dn(void);
  * @return Boolean true if the filenames should be translated, false if we should use English
  */
 int locale_translate_rank_autosaves(void);
+
+/**
+ * Returns a character to use as a thousands-separator in large numbers.
+ * @return character value to use as separator, 0 if no separator should be used. 
+ */
+uint8_t locale_number_thousands_separator(void);
 
 #endif // CORE_LOCALE_H

--- a/src/core/string.c
+++ b/src/core/string.c
@@ -85,7 +85,7 @@ int string_to_int(const uint8_t *str)
     return result;
 }
 
-int string_from_int(uint8_t *dst, int value, int force_plus_sign)
+int string_from_int(uint8_t *dst, int value, int force_plus_sign, uint8_t thousands_separator)
 {
     int total_chars = 0;
     if (value >= 0) {
@@ -108,17 +108,17 @@ int string_from_int(uint8_t *dst, int value, int force_plus_sign)
     } else if (value < 1000) {
         num_digits = 3;
     } else if (value < 10000) {
-        num_digits = 4;
+        num_digits = thousands_separator ? 5 : 4;
     } else if (value < 100000) {
-        num_digits = 5;
+        num_digits = thousands_separator ? 6 : 5;
     } else if (value < 1000000) {
-        num_digits = 6;
+        num_digits = thousands_separator ? 7 : 6;
     } else if (value < 10000000) {
-        num_digits = 7;
+        num_digits = thousands_separator ? 9 : 7;
     } else if (value < 100000000) {
-        num_digits = 8;
+        num_digits = thousands_separator ? 10 : 8;
     } else if (value < 1000000000) {
-        num_digits = 9;
+        num_digits = thousands_separator ? 11 : 9;
     } else {
         num_digits = 0;
     }
@@ -126,9 +126,15 @@ int string_from_int(uint8_t *dst, int value, int force_plus_sign)
     total_chars += num_digits;
 
     dst[num_digits] = 0;
+    int digits_written = 0;
     while (--num_digits >= 0) {
+        if (thousands_separator && (digits_written == 3 || digits_written == 6)) {
+            dst[num_digits] = thousands_separator;
+            --num_digits;
+        }
         dst[num_digits] = (uint8_t) (value % 10 + '0');
         value /= 10;
+        ++digits_written;
     }
 
     return total_chars;

--- a/src/core/string.h
+++ b/src/core/string.h
@@ -51,8 +51,9 @@ int string_to_int(const uint8_t *str);
  * @param dst Output string
  * @param value Value to write
  * @param force_plus_sign Force plus sign in front of positive value
+ * @param thousands_separator character to use for separating groups of digits, or 0 for none
  * @return Total number of characters written to dst
  */
-int string_from_int(uint8_t *dst, int value, int force_plus_sign);
+int string_from_int(uint8_t *dst, int value, int force_plus_sign, uint8_t thousands_separator);
 
 #endif // CORE_STRING_H

--- a/src/graphics/lang_text.c
+++ b/src/graphics/lang_text.c
@@ -50,10 +50,10 @@ int lang_text_draw_amount(int group, int number, int amount, int x_offset, int y
     }
     int desc_offset_x;
     if (amount >= 0) {
-        desc_offset_x = text_draw_number(amount, ' ', " ",
+        desc_offset_x = text_draw_number_with_separator(amount, ' ', " ",
             x_offset, y_offset, font);
     } else {
-        desc_offset_x = text_draw_number(-amount, '-', " ",
+        desc_offset_x = text_draw_number_with_separator(-amount, '-', " ",
             x_offset, y_offset, font);
     }
     return desc_offset_x + lang_text_draw(group, number + amount_offset,

--- a/src/graphics/text.c
+++ b/src/graphics/text.c
@@ -313,13 +313,13 @@ int text_draw(const uint8_t *str, int x, int y, font_t font, color_t color)
     return current_x - x;
 }
 
-static int number_to_string(uint8_t *str, int value, char prefix, const char *postfix)
+static int number_to_string(uint8_t *str, int value, char prefix, const char *postfix, uint8_t thousands_separator)
 {
     int offset = 0;
     if (prefix) {
         str[offset++] = prefix;
     }
-    offset += string_from_int(&str[offset], value, 0);
+    offset += string_from_int(&str[offset], value, 0, thousands_separator);
     while (*postfix) {
         str[offset++] = *postfix;
         postfix++;
@@ -331,7 +331,14 @@ static int number_to_string(uint8_t *str, int value, char prefix, const char *po
 int text_draw_number(int value, char prefix, const char *postfix, int x_offset, int y_offset, font_t font)
 {
     uint8_t str[NUMBER_BUFFER_LENGTH];
-    number_to_string(str, value, prefix, postfix);
+    number_to_string(str, value, prefix, postfix, 0);
+    return text_draw(str, x_offset, y_offset, font, 0);
+}
+
+int text_draw_number_with_separator(int value, char prefix, const char* postfix, int x_offset, int y_offset, font_t font)
+{
+    uint8_t str[NUMBER_BUFFER_LENGTH];
+    number_to_string(str, value, prefix, postfix, locale_number_thousands_separator());
     return text_draw(str, x_offset, y_offset, font, 0);
 }
 
@@ -339,14 +346,22 @@ int text_draw_number_colored(
     int value, char prefix, const char *postfix, int x_offset, int y_offset, font_t font, color_t color)
 {
     uint8_t str[NUMBER_BUFFER_LENGTH];
-    number_to_string(str, value, prefix, postfix);
+    number_to_string(str, value, prefix, postfix, 0);
+    return text_draw(str, x_offset, y_offset, font, color);
+}
+
+int text_draw_number_colored_with_separator(
+    int value, char prefix, const char* postfix, int x_offset, int y_offset, font_t font, color_t color)
+{
+    uint8_t str[NUMBER_BUFFER_LENGTH];
+    number_to_string(str, value, prefix, postfix, locale_number_thousands_separator());
     return text_draw(str, x_offset, y_offset, font, color);
 }
 
 int text_draw_money(int value, int x_offset, int y_offset, font_t font)
 {
     uint8_t str[NUMBER_BUFFER_LENGTH];
-    int money_len = number_to_string(str, value, '@', " ");
+    int money_len = number_to_string(str, value, '@', " ", locale_number_thousands_separator());
     const uint8_t *postfix;
     if (locale_translate_money_dn()) {
         postfix = lang_get_string(6, 0);
@@ -365,7 +380,7 @@ void text_draw_with_money(const uint8_t *text, int value, const char *prefix, co
     if (prefix && *prefix) {
         offset = string_copy(string_from_ascii(prefix), offset, NUMBER_BUFFER_LENGTH - (int) (offset - str) - 1);
     }
-    offset += number_to_string(offset, value, 0, " ");
+    offset += number_to_string(offset, value, 0, " ", locale_number_thousands_separator());
     const uint8_t *money_postfix;
     if (locale_translate_money_dn()) {
         money_postfix = lang_get_string(6, 0);
@@ -386,7 +401,7 @@ void text_draw_with_money(const uint8_t *text, int value, const char *prefix, co
 int text_draw_percentage(int value, int x_offset, int y_offset, font_t font)
 {
     uint8_t str[NUMBER_BUFFER_LENGTH];
-    number_to_string(str, value, '@', "%");
+    number_to_string(str, value, '@', "%", 0);
     return text_draw(str, x_offset, y_offset, font, 0);
 }
 
@@ -394,7 +409,7 @@ int text_draw_label_and_number(const uint8_t *label, int value, const char *post
 {
     uint8_t str[2 * NUMBER_BUFFER_LENGTH];
     uint8_t *pos = label ? string_copy(label, str, NUMBER_BUFFER_LENGTH) : str;
-    number_to_string(pos, value, '@', postfix);
+    number_to_string(pos, value, '@', postfix, 0);
     return text_draw(str, x_offset, y_offset, font, color);
 }
 
@@ -402,21 +417,28 @@ void text_draw_label_and_number_centered(const uint8_t *label, int value, const 
 {
     uint8_t str[2 * NUMBER_BUFFER_LENGTH];
     uint8_t *pos = label ? string_copy(label, str, NUMBER_BUFFER_LENGTH) : str;
-    number_to_string(pos, value, '@', postfix);
+    number_to_string(pos, value, '@', postfix, 0);
     text_draw_centered(str, x_offset, y_offset, box_width, font, color);
 }
 
 void text_draw_number_centered(int value, int x_offset, int y_offset, int box_width, font_t font)
 {
     uint8_t str[NUMBER_BUFFER_LENGTH];
-    number_to_string(str, value, '@', " ");
+    number_to_string(str, value, '@', " ", 0);
+    text_draw_centered(str, x_offset, y_offset, box_width, font, 0);
+}
+
+void text_draw_number_centered_with_separator(int value, int x_offset, int y_offset, int box_width, font_t font)
+{
+    uint8_t str[NUMBER_BUFFER_LENGTH];
+    number_to_string(str, value, '@', " ", locale_number_thousands_separator());
     text_draw_centered(str, x_offset, y_offset, box_width, font, 0);
 }
 
 void text_draw_number_centered_prefix(int value, char prefix, int x_offset, int y_offset, int box_width, font_t font)
 {
     uint8_t str[NUMBER_BUFFER_LENGTH];
-    number_to_string(str, value, prefix, " ");
+    number_to_string(str, value, prefix, " ", 0);
     text_draw_centered(str, x_offset, y_offset, box_width, font, 0);
 }
 
@@ -424,7 +446,7 @@ void text_draw_number_centered_colored(
     int value, int x_offset, int y_offset, int box_width, font_t font, color_t color)
 {
     uint8_t str[NUMBER_BUFFER_LENGTH];
-    number_to_string(str, value, '@', " ");
+    number_to_string(str, value, '@', " ", 0);
     text_draw_centered(str, x_offset, y_offset, box_width, font, color);
 }
 

--- a/src/graphics/text.h
+++ b/src/graphics/text.h
@@ -21,7 +21,10 @@ void text_draw_centered(const uint8_t *str, int x, int y, int box_width, font_t 
 int text_draw_ellipsized(const uint8_t *str, int x, int y, int box_width, font_t font, color_t color);
 
 int text_draw_number(int value, char prefix, const char *postfix, int x_offset, int y_offset, font_t font);
+int text_draw_number_with_separator(int value, char prefix, const char *postfix, int x_offset, int y_offset, font_t font);
 int text_draw_number_colored(
+    int value, char prefix, const char *postfix, int x_offset, int y_offset, font_t font, color_t color);
+int text_draw_number_colored_with_separator(
     int value, char prefix, const char *postfix, int x_offset, int y_offset, font_t font, color_t color);
 int text_draw_money(int value, int x_offset, int y_offset, font_t font);
 void text_draw_with_money(const uint8_t *text, int value, const char *prefix, const char *postfix,
@@ -32,6 +35,7 @@ int text_draw_label_and_number(const uint8_t *label, int value, const char *post
 void text_draw_label_and_number_centered(const uint8_t *label, int value, const char *postfix, int x_offset, int y_offset, int box_width, font_t font, color_t color);
 
 void text_draw_number_centered(int value, int x_offset, int y_offset, int box_width, font_t font);
+void text_draw_number_centered_with_separator(int value, int x_offset, int y_offset, int box_width, font_t font);
 void text_draw_number_centered_prefix(
     int value, char prefix, int x_offset, int y_offset, int box_width, font_t font);
 void text_draw_number_centered_colored(

--- a/src/graphics/tooltip.c
+++ b/src/graphics/tooltip.c
@@ -110,7 +110,7 @@ static const uint8_t *get_tooltip_text(const tooltip_context *c)
         text = lang_get_string(c->text_group, c->text_id);
     }
     if (c->has_numeric_prefix) {
-        int offset = string_from_int(composed_tooltip_text, c->numeric_prefix, 0);
+        int offset = string_from_int(composed_tooltip_text, c->numeric_prefix, 0, 0);
         string_copy(text, &composed_tooltip_text[offset], COMPOSED_TOOLTIP_TEXT_MAX - offset);
         text = composed_tooltip_text;
     } else if (c->num_extra_texts > 0) {

--- a/src/widget/top_menu.c
+++ b/src/widget/top_menu.c
@@ -244,10 +244,10 @@ void widget_top_menu_draw(int force)
         data.offset_date = 547;
 
         int width = lang_text_draw_colored(6, 0, 350, 5, FONT_NORMAL_PLAIN, treasure_color);
-        text_draw_number_colored(treasury, '@', " ", 346 + width, 5, FONT_NORMAL_PLAIN, treasure_color);
+        text_draw_number_colored_with_separator(treasury, '@', " ", 346 + width, 5, FONT_NORMAL_PLAIN, treasure_color);
 
         width = lang_text_draw(6, 1, 458, 5, FONT_NORMAL_GREEN);
-        text_draw_number(city_population(), '@', " ", 450 + width, 5, FONT_NORMAL_GREEN);
+        text_draw_number_colored_with_separator(city_population(), '@', " ", 450 + width, 5, FONT_NORMAL_GREEN, COLOR_WHITE);
 
         lang_text_draw_month_year_max_width(game_time_month(), game_time_year(), 540, 5, 100, FONT_NORMAL_GREEN, 0);
     } else if (s_width < 1024) {
@@ -256,10 +256,10 @@ void widget_top_menu_draw(int force)
         data.offset_date = 652;
 
         int width = lang_text_draw_colored(6, 0, 350, 5, FONT_NORMAL_PLAIN, treasure_color);
-        text_draw_number_colored(treasury, '@', " ", 346 + width, 5, FONT_NORMAL_PLAIN, treasure_color);
+        text_draw_number_colored_with_separator(treasury, '@', " ", 346 + width, 5, FONT_NORMAL_PLAIN, treasure_color);
 
         width = lang_text_draw_colored(6, 1, 470, 5, FONT_NORMAL_PLAIN, COLOR_WHITE);
-        text_draw_number_colored(city_population(), '@', " ", 466 + width, 5, FONT_NORMAL_PLAIN, COLOR_WHITE);
+        text_draw_number_colored_with_separator(city_population(), '@', " ", 466 + width, 5, FONT_NORMAL_PLAIN, COLOR_WHITE);
 
         lang_text_draw_month_year_max_width(game_time_month(), game_time_year(),
             655, 5, 110, FONT_NORMAL_PLAIN, COLOR_FONT_YELLOW);
@@ -269,10 +269,10 @@ void widget_top_menu_draw(int force)
         data.offset_date = 852;
 
         int width = lang_text_draw_colored(6, 0, 495, 5, FONT_NORMAL_PLAIN, treasure_color);
-        text_draw_number_colored(treasury, '@', " ", 501 + width, 5, FONT_NORMAL_PLAIN, treasure_color);
+        text_draw_number_colored_with_separator(treasury, '@', " ", 501 + width, 5, FONT_NORMAL_PLAIN, treasure_color);
 
         width = lang_text_draw_colored(6, 1, 645, 5, FONT_NORMAL_PLAIN, COLOR_WHITE);
-        text_draw_number_colored(city_population(), '@', " ", 651 + width, 5, FONT_NORMAL_PLAIN, COLOR_WHITE);
+        text_draw_number_colored_with_separator(city_population(), '@', " ", 651 + width, 5, FONT_NORMAL_PLAIN, COLOR_WHITE);
 
         lang_text_draw_month_year_max_width(game_time_month(), game_time_year(),
             850, 5, 110, FONT_NORMAL_PLAIN, COLOR_FONT_YELLOW);

--- a/src/window/advisor/chief.c
+++ b/src/window/advisor/chief.c
@@ -46,7 +46,7 @@ static int draw_background(void)
     if (city_labor_unemployment_percentage() > 0) {
         width = lang_text_draw(61, 12, X_OFFSET, 66, FONT_NORMAL_RED);
         width += text_draw_percentage(city_labor_unemployment_percentage(), X_OFFSET + width, 66, FONT_NORMAL_RED);
-        text_draw_number(city_labor_workers_unemployed() - city_labor_workers_needed(), '(', ")",
+        text_draw_number_with_separator(city_labor_workers_unemployed() - city_labor_workers_needed(), '(', ")",
             X_OFFSET + width, 66, FONT_NORMAL_RED);
     } else if (city_labor_workers_needed() > 0) {
         width = lang_text_draw(61, 13, X_OFFSET, 66, FONT_NORMAL_RED);
@@ -108,7 +108,7 @@ static int draw_background(void)
         width = text_draw(translation_for(TR_ADVISOR_HOUSING_NO_ROOM), X_OFFSET, 126, FONT_NORMAL_GREEN, 0);
     } else {
         width = text_draw(translation_for(TR_ADVISOR_HOUSING_ROOM), X_OFFSET, 126, FONT_NORMAL_GREEN, 0);
-        text_draw_number(city_population_open_housing_capacity(), '@', " ", X_OFFSET + width, 126, FONT_NORMAL_GREEN);
+        text_draw_number_with_separator(city_population_open_housing_capacity(), '@', " ", X_OFFSET + width, 126, FONT_NORMAL_GREEN);
     }
 
     // food stocks

--- a/src/window/advisor/education.c
+++ b/src/window/advisor/education.c
@@ -59,11 +59,11 @@ static int draw_background(void)
     lang_text_draw(57, 0, 60, 12, FONT_LARGE_BLACK);
 
     // x population, y school age, z academy age
-    int width = text_draw_number(city_population(), '@', " ", 60, 50, FONT_NORMAL_BLACK);
+    int width = text_draw_number_with_separator(city_population(), '@', " ", 60, 50, FONT_NORMAL_BLACK);
     width += lang_text_draw(57, 1, 60 + width, 50, FONT_NORMAL_BLACK);
-    width += text_draw_number(city_population_school_age(), '@', " ", 60 + width, 50, FONT_NORMAL_BLACK);
+    width += text_draw_number_with_separator(city_population_school_age(), '@', " ", 60 + width, 50, FONT_NORMAL_BLACK);
     width += lang_text_draw(57, 2, 60 + width, 50, FONT_NORMAL_BLACK);
-    width += text_draw_number(city_population_academy_age(), '@', " ", 60 + width, 50, FONT_NORMAL_BLACK);
+    width += text_draw_number_with_separator(city_population_academy_age(), '@', " ", 60 + width, 50, FONT_NORMAL_BLACK);
     lang_text_draw(57, 3, 60 + width, 50, FONT_NORMAL_BLACK);
 
     // table headers
@@ -77,7 +77,7 @@ static int draw_background(void)
     lang_text_draw_amount(8, 18, building_count_total(BUILDING_SCHOOL), 40, 105, FONT_NORMAL_WHITE);
     text_draw_number_centered(building_count_active(BUILDING_SCHOOL), 150, 105, 100, FONT_NORMAL_WHITE);
 
-    width = text_draw_number(city_culture_get_school_person_coverage(), '@', " ", 280, 105, FONT_NORMAL_WHITE);
+    width = text_draw_number_with_separator(city_culture_get_school_person_coverage(), '@', " ", 280, 105, FONT_NORMAL_WHITE);
     lang_text_draw(57, 7, 280 + width, 105, FONT_NORMAL_WHITE);
 
     int pct_school = city_culture_coverage_school();
@@ -93,7 +93,7 @@ static int draw_background(void)
     lang_text_draw_amount(8, 20, building_count_total(BUILDING_ACADEMY), 40, 125, FONT_NORMAL_WHITE);
     text_draw_number_centered(building_count_active(BUILDING_ACADEMY), 150, 125, 100, FONT_NORMAL_WHITE);
 
-    width = text_draw_number(city_culture_get_academy_person_coverage(), '@', " ", 280, 125, FONT_NORMAL_WHITE);
+    width = text_draw_number_with_separator(city_culture_get_academy_person_coverage(), '@', " ", 280, 125, FONT_NORMAL_WHITE);
     lang_text_draw(57, 8, 280 + width, 125, FONT_NORMAL_WHITE);
 
     int pct_academy = city_culture_coverage_academy();
@@ -109,7 +109,7 @@ static int draw_background(void)
     lang_text_draw_amount(8, 22, building_count_total(BUILDING_LIBRARY), 40, 145, FONT_NORMAL_WHITE);
     text_draw_number_centered(building_count_active(BUILDING_LIBRARY), 150, 145, 100, FONT_NORMAL_WHITE);
 
-    width = text_draw_number(city_culture_get_library_person_coverage(), '@', " ", 280, 145, FONT_NORMAL_WHITE);
+    width = text_draw_number_with_separator(city_culture_get_library_person_coverage(), '@', " ", 280, 145, FONT_NORMAL_WHITE);
     lang_text_draw(57, 9, 280 + width, 145, FONT_NORMAL_WHITE);
 
     int pct_library = city_culture_coverage_library();

--- a/src/window/advisor/entertainment.c
+++ b/src/window/advisor/entertainment.c
@@ -108,7 +108,7 @@ static int draw_background(void)
     text_draw(translation_for(TR_WINDOW_ADVISOR_ENTERTAINMENT_TAVERN_COVERAGE), 67, 64, FONT_NORMAL_WHITE, 0);
     text_draw_number(building_count_total(BUILDING_TAVERN), '@', "", 40, 64, FONT_NORMAL_WHITE);
     text_draw_number_centered(building_count_active(BUILDING_TAVERN), 150, 64, 100, FONT_NORMAL_WHITE);
-    int width = text_draw_number(city_culture_get_tavern_person_coverage(), '_', " ",
+    int width = text_draw_number_with_separator(city_culture_get_tavern_person_coverage(), '_', " ",
         PEOPLE_OFFSET, 64, FONT_NORMAL_WHITE);
     lang_text_draw(58, 5, PEOPLE_OFFSET + width, 64, FONT_NORMAL_WHITE);
     int pct_tavern = city_culture_coverage_tavern();
@@ -125,7 +125,7 @@ static int draw_background(void)
     lang_text_draw_amount(8, 34, building_count_total(BUILDING_THEATER), 40, 84, FONT_NORMAL_WHITE);
     text_draw_number_centered(building_count_active(BUILDING_THEATER), 150, 84, 100, FONT_NORMAL_WHITE);
     text_draw_number_centered(city_entertainment_theater_shows(), 230, 84, 100, FONT_NORMAL_WHITE);
-    width = text_draw_number(city_culture_get_theatre_person_coverage(), '_', " ",
+    width = text_draw_number_with_separator(city_culture_get_theatre_person_coverage(), '_', " ",
         PEOPLE_OFFSET, 84, FONT_NORMAL_WHITE);
     lang_text_draw(58, 5, PEOPLE_OFFSET + width, 84, FONT_NORMAL_WHITE);
     int pct_theater = city_culture_coverage_theater();
@@ -142,7 +142,7 @@ static int draw_background(void)
     lang_text_draw_amount(8, 36, building_count_total(BUILDING_AMPHITHEATER), 40, 104, FONT_NORMAL_WHITE);
     text_draw_number_centered(building_count_active(BUILDING_AMPHITHEATER), 150, 104, 100, FONT_NORMAL_WHITE);
     text_draw_number_centered(city_entertainment_amphitheater_shows(), 230, 104, 100, FONT_NORMAL_WHITE);
-    width = text_draw_number(city_culture_get_ampitheatre_person_coverage(), '@', " ",
+    width = text_draw_number_with_separator(city_culture_get_ampitheatre_person_coverage(), '@', " ",
         PEOPLE_OFFSET, 104, FONT_NORMAL_WHITE);
     lang_text_draw(58, 5, PEOPLE_OFFSET + width, 104, FONT_NORMAL_WHITE);
     int pct_amphitheater = city_culture_coverage_amphitheater();
@@ -159,7 +159,7 @@ static int draw_background(void)
     text_draw(translation_for(TR_WINDOW_ADVISOR_ENTERTAINMENT_ARENA_COVERAGE), 67, 124, FONT_NORMAL_WHITE, 0);
     text_draw_number(building_count_total(BUILDING_ARENA), '@', "", 40, 124, FONT_NORMAL_WHITE);
     text_draw_number_centered(building_count_active(BUILDING_ARENA), 150, 124, 100, FONT_NORMAL_WHITE);
-    width = text_draw_number(city_culture_get_arena_person_coverage(), '_', " ", PEOPLE_OFFSET, 124, FONT_NORMAL_WHITE);
+    width = text_draw_number_with_separator(city_culture_get_arena_person_coverage(), '_', " ", PEOPLE_OFFSET, 124, FONT_NORMAL_WHITE);
     lang_text_draw(58, 5, PEOPLE_OFFSET + width, 124, FONT_NORMAL_WHITE);
     text_draw_number_centered(city_entertainment_colosseum_shows(), 230, 124, 100, FONT_NORMAL_WHITE);
     int pct = city_culture_coverage_arena();

--- a/src/window/advisor/financial.c
+++ b/src/window/advisor/financial.c
@@ -26,15 +26,15 @@ static int arrow_button_focus;
 static void draw_row(int group, int number, int y, int value_last_year, int value_this_year)
 {
     lang_text_draw(group, number, 80, y, FONT_NORMAL_BLACK);
-    text_draw_number(value_last_year, '@', " ", 290, y, FONT_NORMAL_BLACK);
-    text_draw_number(value_this_year, '@', " ", 430, y, FONT_NORMAL_BLACK);
+    text_draw_number_with_separator(value_last_year, '@', " ", 290, y, FONT_NORMAL_BLACK);
+    text_draw_number_with_separator(value_this_year, '@', " ", 430, y, FONT_NORMAL_BLACK);
 }
 
 static void draw_tr_row(int tr_string, int y, int value_last_year, int value_this_year)
 {
     text_draw(translation_for(tr_string), 80, y, FONT_NORMAL_BLACK, 0);
-    text_draw_number(value_last_year, '@', " ", 290, y, FONT_NORMAL_BLACK);
-    text_draw_number(value_this_year, '@', " ", 430, y, FONT_NORMAL_BLACK);
+    text_draw_number_with_separator(value_last_year, '@', " ", 290, y, FONT_NORMAL_BLACK);
+    text_draw_number_with_separator(value_this_year, '@', " ", 430, y, FONT_NORMAL_BLACK);
 }
 
 static int draw_background(void)

--- a/src/window/advisor/housing.c
+++ b/src/window/advisor/housing.c
@@ -52,10 +52,10 @@ static void draw_housing_table()
     text_draw_number(calculate_total_housing_buildings(), '@', " ", 500, y_offset + 180, FONT_NORMAL_WHITE);
 
     text_draw(translation_for(TR_ADVISOR_AVAILABLE_HOUSING_CAPACITY), 320, y_offset + 200, FONT_NORMAL_GREEN, 0);
-    text_draw_number(city_population_open_housing_capacity(), '@', " ", 500, y_offset + 200, FONT_NORMAL_WHITE);
+    text_draw_number_with_separator(city_population_open_housing_capacity(), '@', " ", 500, y_offset + 200, FONT_NORMAL_WHITE);
 
     text_draw(translation_for(TR_ADVISOR_TOTAL_HOUSING_CAPACITY), 320, y_offset + 220, FONT_NORMAL_GREEN, 0);
-    text_draw_number(city_population_total_housing_capacity(), '@', " ", 500, y_offset + 220, FONT_NORMAL_WHITE);
+    text_draw_number_with_separator(city_population_total_housing_capacity(), '@', " ", 500, y_offset + 220, FONT_NORMAL_WHITE);
 
     for (int i = 0; i <= 3; i++) {
         image_draw(image_group(GROUP_RESOURCE_ICONS) + goods_icons[i], 54, y_offset + 260 + (23 * i));
@@ -78,13 +78,13 @@ static int draw_background(void)
 
     static uint8_t pop[32];
     pop[0] = ' ';
-    string_from_int(pop + 1, city_population(), 0);
+    string_from_int(pop + 1, city_population(), 0, locale_number_thousands_separator());
 
     int x_offset = text_get_width(pop, FONT_NORMAL_BLACK);
     x_offset += lang_text_get_width(CUSTOM_TRANSLATION, TR_ADVISOR_TOTAL_POPULATION, FONT_NORMAL_BLACK);
     x_offset = 620 - x_offset;
 
-    int width = text_draw_number(city_population(), 0, "", x_offset, 25, FONT_NORMAL_BLACK);
+    int width = text_draw_number_with_separator(city_population(), 0, "", x_offset, 25, FONT_NORMAL_BLACK);
     text_draw(translation_for(TR_ADVISOR_TOTAL_POPULATION), x_offset + width, 25, FONT_NORMAL_BLACK, 0);
 
     draw_housing_table();

--- a/src/window/advisor/imperial.c
+++ b/src/window/advisor/imperial.c
@@ -69,7 +69,7 @@ static void draw_request(int index, const scenario_request *request)
     if (request->resource == RESOURCE_DENARII) {
         // request for money
         int treasury = city_finance_treasury();
-        width = text_draw_number(treasury, '@', " ", 40, 120 + 42 * index, FONT_NORMAL_WHITE);
+        width = text_draw_number_with_separator(treasury, '@', " ", 40, 120 + 42 * index, FONT_NORMAL_WHITE);
         width += lang_text_draw(52, 44, 40 + width, 120 + 42 * index, FONT_NORMAL_WHITE);
         if (treasury < request->amount) {
             lang_text_draw(52, 48, 80 + width, 120 + 42 * index, FONT_NORMAL_WHITE);
@@ -277,13 +277,13 @@ static void write_resource_storage_tooltip(advisor_tooltip_result *r, int resour
     int amount_warehouse = city_resource_count(resource);
     int amount_granary = city_resource_count_food_on_granaries(resource) / RESOURCE_GRANARY_ONE_LOAD;
     uint8_t *text = tooltip_resource_info;
-    text += string_from_int(text, amount_warehouse, 0);
+    text += string_from_int(text, amount_warehouse, 0, 0);
     *text = ' ';
     text++;
     text = string_copy(lang_get_string(52, 43), text, RESOURCE_INFO_MAX_TEXT - (int) (text - tooltip_resource_info));
     *text = '\n';
     text++;
-    text += string_from_int(text, amount_granary, 0);
+    text += string_from_int(text, amount_granary, 0, locale_number_thousands_separator());
     *text = ' ';
     text++;
     text = string_copy(translation_for(TR_ADVISOR_FROM_GRANARIES), text, RESOURCE_INFO_MAX_TEXT - (int) (text - tooltip_resource_info));

--- a/src/window/advisor/labor.c
+++ b/src/window/advisor/labor.c
@@ -51,9 +51,9 @@ static int draw_background(void)
     lang_text_draw(50, 24, 500, 56, FONT_SMALL_PLAIN);
 
     // xx employed, yy unemployed
-    int width = text_draw_number(city_labor_workers_employed(), '@', " ", 32, 320, FONT_NORMAL_BLACK);
+    int width = text_draw_number_with_separator(city_labor_workers_employed(), '@', " ", 32, 320, FONT_NORMAL_BLACK);
     width += lang_text_draw(50, 12, 32 + width, 320, FONT_NORMAL_BLACK);
-    width += text_draw_number(city_labor_workers_unemployed(), '@', " ", 50 + width, 320, FONT_NORMAL_BLACK);
+    width += text_draw_number_with_separator(city_labor_workers_unemployed(), '@', " ", 50 + width, 320, FONT_NORMAL_BLACK);
     width += lang_text_draw(50, 13, 50 + width, 320, FONT_NORMAL_BLACK);
     text_draw_number(city_labor_unemployment_percentage(), '@', "%)", 50 + width, 320, FONT_NORMAL_BLACK);
 
@@ -88,12 +88,12 @@ static void draw_foreground(void)
             text_draw_number(cat->priority, '@', " ", 90, y_offset, FONT_NORMAL_WHITE);
         }
         lang_text_draw(50, i + 1, 170, y_offset, FONT_NORMAL_WHITE);
-        text_draw_number(cat->workers_needed, '@', " ", 410, y_offset, FONT_NORMAL_WHITE);
+        text_draw_number_with_separator(cat->workers_needed, '@', " ", 410, y_offset, FONT_NORMAL_WHITE);
         font_t font = FONT_NORMAL_WHITE;
         if (cat->workers_needed != cat->workers_allocated) {
             font = FONT_NORMAL_RED;
         }
-        text_draw_number(cat->workers_allocated, '@', " ", 510, y_offset, font);
+        text_draw_number_with_separator(cat->workers_allocated, '@', " ", 510, y_offset, font);
     }
 }
 

--- a/src/window/advisor/population.c
+++ b/src/window/advisor/population.c
@@ -94,8 +94,8 @@ static void draw_history_graph(int full_size, int x, int y)
     get_y_axis(max_value, &y_max, &y_shift);
     if (full_size) {
         // y axis
-        text_draw_number_centered(y_max, x - 66, y - 3, 60, FONT_SMALL_PLAIN);
-        text_draw_number_centered(y_max / 2, x - 66, y + 96, 60, FONT_SMALL_PLAIN);
+        text_draw_number_centered_with_separator(y_max, x - 66, y - 3, 60, FONT_SMALL_PLAIN);
+        text_draw_number_centered_with_separator(y_max / 2, x - 66, y + 96, 60, FONT_SMALL_PLAIN);
         text_draw_number_centered(0, x - 66, y + 196, 60, FONT_SMALL_PLAIN);
         // x axis
         int start_month, start_year, end_month, end_year;
@@ -284,11 +284,11 @@ static void print_census_info(void)
 
     // Yearly births
     width = text_draw(translation_for(TR_ADVISOR_BIRTHS_LAST_YEAR), 75, 378, FONT_NORMAL_WHITE, 0);
-    text_draw_number(city_population_yearly_births(), '@', "", 75 + width, 378, FONT_NORMAL_WHITE);
+    text_draw_number_with_separator(city_population_yearly_births(), '@', "", 75 + width, 378, FONT_NORMAL_WHITE);
 
     // Yearly deaths
     width = text_draw(translation_for(TR_ADVISOR_DEATHS_LAST_YEAR), 75, 396, FONT_NORMAL_WHITE, 0);
-    text_draw_number(city_population_yearly_deaths(), '@', "", 75 + width, 396, FONT_NORMAL_WHITE);
+    text_draw_number_with_separator(city_population_yearly_deaths(), '@', "", 75 + width, 396, FONT_NORMAL_WHITE);
 }
 
 static void print_history_info(void)
@@ -370,7 +370,7 @@ static int draw_background(void)
 
     image_draw(image_group(GROUP_PANEL_WINDOWS) + 14, 62, 60);
 
-    width = text_draw_number(city_population(), '@', " ", 450, 25, FONT_NORMAL_BLACK);
+    width = text_draw_number_with_separator(city_population(), '@', " ", 450, 25, FONT_NORMAL_BLACK);
     text_draw(translation_for(TR_ADVISOR_TOTAL_POPULATION), 450 + width, 25, FONT_NORMAL_BLACK, 0);
 
     int big_text, top_text, bot_text;

--- a/src/window/advisor/ratings.c
+++ b/src/window/advisor/ratings.c
@@ -52,7 +52,7 @@ static int draw_background(void)
         lang_text_draw(53, 7, 80 + width, 17, FONT_NORMAL_BLACK);
     } else {
         width += lang_text_draw(53, 6, 80 + width, 17, FONT_NORMAL_BLACK);
-        text_draw_number(scenario_criteria_population(), '@', ")", 80 + width, 17, FONT_NORMAL_BLACK);
+        text_draw_number_with_separator(scenario_criteria_population(), '@', ")", 80 + width, 17, FONT_NORMAL_BLACK);
     }
 
     image_draw(image_group(GROUP_RATINGS_BACKGROUND), 60, 48);

--- a/src/window/advisor/trade.c
+++ b/src/window/advisor/trade.c
@@ -323,13 +323,13 @@ static void write_resource_storage_tooltip(advisor_tooltip_result *r, int resour
     int amount_warehouse = city_resource_count(resource);
     int amount_granary = city_resource_count_food_on_granaries(resource) / RESOURCE_GRANARY_ONE_LOAD;
     uint8_t *text = tooltip_resource_info;
-    text += string_from_int(text, amount_warehouse, 0);
+    text += string_from_int(text, amount_warehouse, 0, 0);
     *text = ' ';
     text++;
     text = string_copy(lang_get_string(52, 43), text, 200 - (int) (text - tooltip_resource_info));
     *text = '\n';
     text++;
-    text += string_from_int(text, amount_granary, 0);
+    text += string_from_int(text, amount_granary, 0, locale_number_thousands_separator());
     *text = ' ';
     text++;
     text = string_copy(translation_for(TR_ADVISOR_FROM_GRANARIES), text, 200 - (int) (text - tooltip_resource_info));

--- a/src/window/building/common.c
+++ b/src/window/building/common.c
@@ -125,14 +125,14 @@ static void draw_employment_details(building_info_context *c, building *b, int y
         if (text_id) {
             int width = lang_text_draw_amount(8, 12, b->num_workers,
                 c->x_offset + 60, y_offset + 10, FONT_NORMAL_BROWN);
-            width += text_draw_number(laborers_needed, '(', "",
+            width += text_draw_number_with_separator(laborers_needed, '(', "",
                 c->x_offset + 70 + width, y_offset + 10, FONT_NORMAL_BROWN);
             lang_text_draw(69, 0, c->x_offset + 70 + width, y_offset + 10, FONT_NORMAL_BROWN);
             lang_text_draw(69, text_id, c->x_offset + 70, y_offset + 26, FONT_NORMAL_BROWN);
         } else {
             int width = lang_text_draw_amount(8, 12, b->num_workers,
                 c->x_offset + 60, y_offset + 16, FONT_NORMAL_BROWN);
-            width += text_draw_number(laborers_needed, '(', "",
+            width += text_draw_number_with_separator(laborers_needed, '(', "",
                 c->x_offset + 70 + width, y_offset + 16, FONT_NORMAL_BROWN);
             lang_text_draw(69, 0, c->x_offset + 70 + width, y_offset + 16, FONT_NORMAL_BROWN);
         }

--- a/src/window/cck_selection.c
+++ b/src/window/cck_selection.c
@@ -197,7 +197,7 @@ static void draw_scenario_info(void)
                 lang_text_draw(44, 132, scenario_criteria_x + width, 338, FONT_NORMAL_BLACK);
             }
             if (scenario_criteria_population_enabled()) {
-                width = text_draw_number(scenario_criteria_population(), '@', " ",
+                width = text_draw_number_with_separator(scenario_criteria_population(), '@', " ",
                     scenario_criteria_x, 354, FONT_NORMAL_BLACK);
                 lang_text_draw(44, 133, scenario_criteria_x + width, 354, FONT_NORMAL_BLACK);
             }

--- a/src/window/config.c
+++ b/src/window/config.c
@@ -588,7 +588,7 @@ static void numerical_range_draw(const numerical_range_widget *w, int x, int y, 
 
 static uint8_t *percentage_string(uint8_t *string, int percentage)
 {
-    int offset = string_from_int(string, percentage, 0);
+    int offset = string_from_int(string, percentage, 0, 0);
     string[offset] = '%';
     string[offset + 1] = 0;
     return string;
@@ -608,9 +608,9 @@ static const uint8_t *display_text_resolution(void)
 {
     uint8_t *str = display_text;
     resolution *r = &available_resolutions[data.config_values[CONFIG_ORIGINAL_WINDOWED_RESOLUTION].new_value];
-    str += string_from_int(str, r->width, 0);
+    str += string_from_int(str, r->width, 0, 0);
     str = string_copy(string_from_ascii("x"), str, 5);
-    string_from_int(str, r->height, 0);
+    string_from_int(str, r->height, 0, 0);
     return display_text;
 }
 
@@ -672,7 +672,7 @@ static const uint8_t *display_text_difficulty(void)
 
 static const uint8_t *display_text_max_grand_temples(void)
 {
-    string_from_int(display_text, data.config_values[CONFIG_GP_CH_MAX_GRAND_TEMPLES].new_value, 0);
+    string_from_int(display_text, data.config_values[CONFIG_GP_CH_MAX_GRAND_TEMPLES].new_value, 0, 0);
     return display_text;
 }
 

--- a/src/window/editor/edit_demand_change.c
+++ b/src/window/editor/edit_demand_change.c
@@ -54,7 +54,7 @@ static struct {
 static void create_display_name(int route_id, const uint8_t *city_name)
 {
     uint8_t *dst = route_display_names[route_id];
-    int offset = string_from_int(dst, route_id, 0);
+    int offset = string_from_int(dst, route_id, 0, 0);
     dst[offset++] = ' ';
     dst[offset++] = '-';
     dst[offset++] = ' ';

--- a/src/window/mission_briefing.c
+++ b/src/window/mission_briefing.c
@@ -80,7 +80,7 @@ static void draw_background(void)
         goal_index++;
         label_draw(16 + x, 32 + y, 15, 1);
         int width = lang_text_draw(62, 11, 16 + x + 8, 32 + y + 3, FONT_NORMAL_RED);
-        text_draw_number(scenario_criteria_population(), '@', " ", 16 + x + 8 + width, 32 + y + 3, FONT_NORMAL_RED);
+        text_draw_number_with_separator(scenario_criteria_population(), '@', " ", 16 + x + 8 + width, 32 + y + 3, FONT_NORMAL_RED);
     }
     if (scenario_criteria_culture_enabled()) {
         int x = GOAL_OFFSETS_X[goal_index];

--- a/src/window/mission_end.c
+++ b/src/window/mission_end.c
@@ -90,10 +90,10 @@ static void draw_won(void)
     text_draw_number(city_rating_favor(), '@', " ", right_offset + width, 328, FONT_NORMAL_BLACK);
 
     width = lang_text_draw(148, 4, left_offset, 348, FONT_NORMAL_BLACK);
-    text_draw_number(city_population(), '@', " ", left_offset + width, 348, FONT_NORMAL_BLACK);
+    text_draw_number_with_separator(city_population(), '@', " ", left_offset + width, 348, FONT_NORMAL_BLACK);
 
     width = lang_text_draw(148, 5, right_offset, 348, FONT_NORMAL_BLACK);
-    text_draw_number(city_finance_treasury(), '@', " ", right_offset + width, 348, FONT_NORMAL_BLACK);
+    text_draw_number_with_separator(city_finance_treasury(), '@', " ", right_offset + width, 348, FONT_NORMAL_BLACK);
 
     lang_text_draw_centered(13, 1, 64, 388, 512, FONT_NORMAL_BLACK);
 }


### PR DESCRIPTION
On suggestion from @crudelios, add number separators to aide in readability. `"12345"` -> `"12,345"`, etc. 

In this iteration I use `locale.c:data.last_determined_language` to make a best-guess selection of number separator character in `locale.c:locale_number_thousands_separator()`. The new formatting logic happens in `string.c:string_from_int()`, and is based only on groups of 3 digits. New function variants `text_draw_with_separator()`, `text_draw_number_colored_with_separator()` and `text_draw_number_centerered_with_separator()` will use this separator for printing large numbers. I have updated most places in the code which deal with population or money values to use these new function variants. Many other usages where the values do not routinely go above 1000 are not updated (resource counts, building counts, ratings, etc).
