### PR TITLE
Animals move when you try to build

### DIFF
--- a/src/figuretype/animal.c
+++ b/src/figuretype/animal.c
@@ -17,6 +17,8 @@
 #include "map/figure.h"
 #include "map/grid.h"
 #include "map/point.h"
+#include "map/random.h"
+#include "map/terrain.h"
 #include "scenario/map.h"
 #include "scenario/property.h"
 
@@ -251,6 +253,36 @@ void figure_wolf_action(figure *f)
         f->image_id = image_group(GROUP_FIGURE_WOLF) + 152 + dir;
     } else {
         f->image_id = image_group(GROUP_FIGURE_WOLF) + dir + 8 * f->image_offset;
+    }
+}
+
+static int terrain_blocked_for_animals(int grid_offset)
+{
+    return map_terrain_is(grid_offset, TERRAIN_TREE | TERRAIN_ROCK | TERRAIN_WATER |
+        TERRAIN_BUILDING | TERRAIN_SHRUB );
+}
+
+void figure_animal_try_nudge_at(const map_tile *building_center_tile, int animal_tile_offset, int building_size)
+{
+    int figure_id = map_figure_at(animal_tile_offset);
+    figure *f = figure_get(figure_id);
+    if ((f->type == FIGURE_SHEEP || f->type == FIGURE_ZEBRA) 
+        && f->action_state == FIGURE_ACTION_196_HERD_ANIMAL_AT_REST) {
+        const int num_tiles = building_size * 4;
+        const int *tile_deltas = map_grid_adjacent_offsets(building_size);
+        const int random_value = map_random_get(animal_tile_offset);
+        for (int i = 0; i < num_tiles; i++) {
+            int current_tile_delta = tile_deltas[(random_value + i) % num_tiles];
+            int target_grid_offset = building_center_tile->grid_offset + current_tile_delta;
+            if (terrain_blocked_for_animals(target_grid_offset)) {
+                continue;
+            }
+            f->action_state = FIGURE_ACTION_197_HERD_ANIMAL_MOVING;
+            f->destination_x = map_grid_offset_to_x(target_grid_offset);
+            f->destination_y = map_grid_offset_to_y(target_grid_offset);
+            f->roam_length = 0;
+            break;
+        }
     }
 }
 

--- a/src/figuretype/animal.c
+++ b/src/figuretype/animal.c
@@ -262,7 +262,7 @@ static int terrain_blocked_for_animals(int grid_offset)
         TERRAIN_BUILDING | TERRAIN_SHRUB );
 }
 
-void figure_animal_try_nudge_at(const map_tile *building_center_tile, int animal_tile_offset, int building_size)
+void figure_animal_try_nudge_at(int building_center_tile_grid_offset, int animal_tile_offset, int building_size)
 {
     int figure_id = map_figure_at(animal_tile_offset);
     figure *f = figure_get(figure_id);
@@ -273,7 +273,7 @@ void figure_animal_try_nudge_at(const map_tile *building_center_tile, int animal
         const int random_value = map_random_get(animal_tile_offset);
         for (int i = 0; i < num_tiles; i++) {
             int current_tile_delta = tile_deltas[(random_value + i) % num_tiles];
-            int target_grid_offset = building_center_tile->grid_offset + current_tile_delta;
+            int target_grid_offset = building_center_tile_grid_offset + current_tile_delta;
             if (terrain_blocked_for_animals(target_grid_offset)) {
                 continue;
             }

--- a/src/figuretype/animal.h
+++ b/src/figuretype/animal.h
@@ -20,6 +20,6 @@ void figure_hippodrome_horse_action(figure *f);
 
 void figure_hippodrome_horse_reroute(void);
 
-void figure_animal_try_nudge_at(const map_tile *building_center_tile, int animal_tile_offset, int building_size);
+void figure_animal_try_nudge_at(int building_center_tile_grid_offset, int animal_tile_offset, int building_size);
 
 #endif // FIGURETYPE_ANIMAL_H

--- a/src/figuretype/animal.h
+++ b/src/figuretype/animal.h
@@ -2,7 +2,6 @@
 #define FIGURETYPE_ANIMAL_H
 
 #include "figure/figure.h"
-#include "map/point.h"
 
 void figure_create_fishing_points(void);
 

--- a/src/figuretype/animal.h
+++ b/src/figuretype/animal.h
@@ -2,6 +2,7 @@
 #define FIGURETYPE_ANIMAL_H
 
 #include "figure/figure.h"
+#include "map/point.h"
 
 void figure_create_fishing_points(void);
 
@@ -18,5 +19,7 @@ void figure_zebra_action(figure *f);
 void figure_hippodrome_horse_action(figure *f);
 
 void figure_hippodrome_horse_reroute(void);
+
+void figure_animal_try_nudge_at(const map_tile *building_center_tile, int animal_tile_offset, int building_size);
 
 #endif // FIGURETYPE_ANIMAL_H

--- a/src/map/grid.h
+++ b/src/map/grid.h
@@ -69,7 +69,6 @@ int map_grid_is_inside(int x, int y, int size);
 
 const int *map_grid_adjacent_offsets(int size);
 
-
 void map_grid_clear_u8(uint8_t *grid);
 
 void map_grid_clear_i8(int8_t *grid);

--- a/src/widget/city_building_ghost.c
+++ b/src/widget/city_building_ghost.c
@@ -18,7 +18,9 @@
 #include "core/config.h"
 #include "core/config.h"
 #include "core/log.h"
+#include "figure/figure.h"
 #include "figure/formation.h"
+#include "figuretype/animal.h"
 #include "graphics/image.h"
 #include "input/scroll.h"
 #include "map/bridge.h"
@@ -455,8 +457,12 @@ static void draw_default(const map_tile *tile, int x_view, int y_view, building_
                 forbidden_terrain &= ~TERRAIN_WALL;
             }
         }
-        if (fully_blocked || forbidden_terrain || (map_has_figure_at(tile_offset) && type != BUILDING_PLAZA)) {
+
+        if (fully_blocked || forbidden_terrain) {
             blocked_tiles[i] = 1;
+        } else if (map_has_figure_at(tile_offset) && type != BUILDING_PLAZA) {
+            blocked_tiles[i] = 1;
+            figure_animal_try_nudge_at(tile, tile_offset, building_size);
         } else {
             blocked_tiles[i] = 0;
         }

--- a/src/widget/city_building_ghost.c
+++ b/src/widget/city_building_ghost.c
@@ -159,10 +159,11 @@ static struct {
 static building ghost_building;
 static float scale = SCALE_NONE;
 
-static int is_blocked_for_building(int grid_offset, int num_tiles, int *blocked_tiles)
+static int is_blocked_for_building(int grid_offset, int building_size, int *blocked_tiles)
 {
     int orientation_index = city_view_orientation() / 2;
     int blocked = 0;
+    int num_tiles = building_size * building_size;
     for (int i = 0; i < num_tiles; i++) {
         int tile_offset = grid_offset + TILE_GRID_OFFSETS[orientation_index][i];
         int tile_blocked = 0;
@@ -171,6 +172,7 @@ static int is_blocked_for_building(int grid_offset, int num_tiles, int *blocked_
         }
         if (map_has_figure_at(tile_offset)) {
             tile_blocked = 1;
+            figure_animal_try_nudge_at(grid_offset, tile_offset, building_size);
         }
         blocked_tiles[i] = tile_blocked;
         blocked += tile_blocked;
@@ -462,7 +464,7 @@ static void draw_default(const map_tile *tile, int x_view, int y_view, building_
             blocked_tiles[i] = 1;
         } else if (map_has_figure_at(tile_offset) && type != BUILDING_PLAZA) {
             blocked_tiles[i] = 1;
-            figure_animal_try_nudge_at(tile, tile_offset, building_size);
+            figure_animal_try_nudge_at(grid_offset, tile_offset, building_size);
         } else {
             blocked_tiles[i] = 0;
         }
@@ -716,7 +718,8 @@ static void draw_well(const map_tile *tile, int x, int y)
 static void draw_bathhouse(const map_tile *tile, int x, int y)
 {
     int grid_offset = tile->grid_offset;
-    int num_tiles = 4;
+    const int building_size = 2;
+    const int num_tiles = 4;
     int blocked_tiles[4];
     int blocked = 0;
     color_t color;
@@ -726,7 +729,7 @@ static void draw_bathhouse(const map_tile *tile, int x, int y)
             blocked_tiles[i] = 1;
         }
     } else {
-        blocked = is_blocked_for_building(grid_offset, num_tiles, blocked_tiles);
+        blocked = is_blocked_for_building(grid_offset, building_size, blocked_tiles);
     }
     int image_id = image_group(building_properties_for_type(BUILDING_BATHHOUSE)->image_group);
 
@@ -759,14 +762,15 @@ static void draw_bathhouse(const map_tile *tile, int x, int y)
 static void draw_pond(const map_tile *tile, int x, int y, int type)
 {
     int grid_offset = tile->grid_offset;
-    int num_tiles = (type == BUILDING_LARGE_POND) ? 9 : 4;
+    int building_size = (type == BUILDING_LARGE_POND) ? 3 : 2;
+    int num_tiles = building_size * building_size;
     int blocked_tiles[9];
     if (city_finance_out_of_money()) {
         for (int i = 0; i < num_tiles; i++) {
             blocked_tiles[i] = 1;
         }
     } else {
-        is_blocked_for_building(grid_offset, num_tiles, blocked_tiles);
+        is_blocked_for_building(grid_offset, building_size, blocked_tiles);
     }
 
     int has_water = 0;
@@ -853,10 +857,10 @@ static void draw_fort(const map_tile *tile, int x, int y)
 {
     int blocked = 0;
 
-    int num_tiles_fort = building_properties_for_type(BUILDING_FORT)->size;
-    num_tiles_fort *= num_tiles_fort;
-    int num_tiles_ground = building_properties_for_type(BUILDING_FORT_GROUND)->size;
-    num_tiles_ground *= num_tiles_ground;
+    int building_size_fort = building_properties_for_type(BUILDING_FORT)->size;
+    int num_tiles_fort = building_size_fort * building_size_fort;
+    int building_size_ground = building_properties_for_type(BUILDING_FORT_GROUND)->size;
+    int num_tiles_ground = building_size_ground * building_size_ground;
 
     int grid_offset_fort = tile->grid_offset;
     int grid_offset_ground = grid_offset_fort +
@@ -873,8 +877,8 @@ static void draw_fort(const map_tile *tile, int x, int y)
             blocked_tiles_ground[i] = 1;
         }
     } else {
-        blocked |= is_blocked_for_building(grid_offset_fort, num_tiles_fort, blocked_tiles_fort);
-        blocked |= is_blocked_for_building(grid_offset_ground, num_tiles_ground, blocked_tiles_ground);
+        blocked |= is_blocked_for_building(grid_offset_fort, building_size_fort, blocked_tiles_fort);
+        blocked |= is_blocked_for_building(grid_offset_ground, building_size_ground, blocked_tiles_ground);
     }
 
     int orientation_index = building_rotation_get_building_orientation(building_rotation_get_rotation()) / 2;
@@ -907,7 +911,8 @@ static void draw_hippodrome(const map_tile *tile, int x, int y)
     if (city_buildings_has_hippodrome() || city_finance_out_of_money()) {
         blocked = 1;
     }
-    int num_tiles = 25;
+    const int building_block_size = 5;
+    const int num_tiles = 25;
 
     building_rotation_force_two_orientations();
     int orientation_index = building_rotation_get_building_orientation(building_rotation_get_rotation()) / 2;
@@ -926,9 +931,9 @@ static void draw_hippodrome(const map_tile *tile, int x, int y)
             blocked_tiles3[i] = 1;
         }
     } else {
-        blocked |= is_blocked_for_building(grid_offset1, num_tiles, blocked_tiles1);
-        blocked |= is_blocked_for_building(grid_offset2, num_tiles, blocked_tiles2);
-        blocked |= is_blocked_for_building(grid_offset3, num_tiles, blocked_tiles3);
+        blocked |= is_blocked_for_building(grid_offset1, building_block_size, blocked_tiles1);
+        blocked |= is_blocked_for_building(grid_offset2, building_block_size, blocked_tiles2);
+        blocked |= is_blocked_for_building(grid_offset3, building_block_size, blocked_tiles3);
     }
 
     int x_part1 = x;


### PR DESCRIPTION
If you hover a building ghost over an animal, that animal will try to move out of your way.
Only sheep and zebras move. Wolves don't care about you or your city.
Animals try to move to a randomly selected adjacent offset.

IN THE FUTURE: I don't do anything with the formation. It really might be a good idea to re-form the formation so animals don't get scattered away from each other too much. Also in the future it would be nice if zebras ran farther away, they don't seem like they're the type for minimal movements.