### PR TITLE
Small improvements for empire/city.c:generate_trader()

### DIFF
--- a/src/empire/city.c
+++ b/src/empire/city.c
@@ -270,11 +270,12 @@ static int generate_trader(int city_id, empire_city *city)
     }
 
     // Find a slot to hold a trader
-    int max_traders = calc_bound(trade_potential / RESOURCES_TO_TRADER_RATIO + 1, 1, MAX_TRADERS);
+    int max_traders = calc_bound(trade_potential / RESOURCES_TO_TRADER_RATIO + 1, 1, EMPIRE_CITY_MAX_TRADERS);
     int index = -1;
-    for (int f = 0; f < max_traders; f++) {
-        if (!city->trader_figure_ids[f]) {
-            index = f;
+    for (int i = 0; i < max_traders; i++) {
+        if (!city->trader_figure_ids[i]) {
+            index = i;
+            break;
         }
     }
     if (index == -1) {
@@ -335,7 +336,7 @@ void empire_city_generate_trader(void)
 
 void empire_city_remove_trader(int city_id, int figure_id)
 {
-    for (int i = 0; i < MAX_TRADERS; i++) {
+    for (int i = 0; i < EMPIRE_CITY_MAX_TRADERS; i++) {
         if (cities[city_id].trader_figure_ids[i] == figure_id) {
             cities[city_id].trader_figure_ids[i] = 0;
         }
@@ -388,7 +389,7 @@ void empire_city_save_state(buffer *buf)
         buffer_write_i16(buf, city->empire_object_id);
         buffer_write_u8(buf, city->is_sea_trade);
         buffer_write_u8(buf, 0);
-        for (int f = 0; f < MAX_TRADERS; f++) {
+        for (int f = 0; f < EMPIRE_CITY_MAX_TRADERS; f++) {
             buffer_write_i16(buf, city->trader_figure_ids[f]);
         }
         for (int p = 0; p < 10; p++) {
@@ -420,7 +421,7 @@ void empire_city_load_state(buffer *buf)
         city->empire_object_id = buffer_read_i16(buf);
         city->is_sea_trade = buffer_read_u8(buf);
         buffer_skip(buf, 1);
-        for (int f = 0; f < MAX_TRADERS; f++) {
+        for (int f = 0; f < EMPIRE_CITY_MAX_TRADERS; f++) {
             city->trader_figure_ids[f] = buffer_read_i16(buf);
         }
         buffer_skip(buf, 10);

--- a/src/empire/city.c
+++ b/src/empire/city.c
@@ -17,6 +17,8 @@
 
 #define MAX_CITIES 41
 #define RESOURCES_TO_TRADER_RATIO 60
+#define LAND_TRADER_DELAY_TICKS 4
+#define SEA_TRADER_DELAY_TICKS 30
 
 static empire_city cities[MAX_CITIES];
 
@@ -249,6 +251,14 @@ void empire_city_force_sell(int route, int resource)
 
 static int generate_trader(int city_id, empire_city *city)
 {
+    // Check timeout before city can send another trader
+    if (city->trader_entry_delay > 0) {
+        city->trader_entry_delay--;
+        return 0;
+    }
+    city->trader_entry_delay = city->is_sea_trade ? SEA_TRADER_DELAY_TICKS : LAND_TRADER_DELAY_TICKS;
+
+    // Check that we have space to trade
     int trade_potential = 0;
     for (int r = RESOURCE_MIN; r < RESOURCE_MAX; r++) {
         if (city->buys_resource[r] || city->sells_resource[r]) {
@@ -258,39 +268,18 @@ static int generate_trader(int city_id, empire_city *city)
     if (trade_potential <= 0) {
         return 0;
     }
-    int max_traders = calc_bound(trade_potential / RESOURCES_TO_TRADER_RATIO + 1, 1, 3);
-    int index;
-    if (max_traders == 1) {
-        if (!city->trader_figure_ids[0]) {
-            index = 0;
-        } else {
-            return 0;
-        }
-    } else if (max_traders == 2) {
-        if (!city->trader_figure_ids[0]) {
-            index = 0;
-        } else if (!city->trader_figure_ids[1]) {
-            index = 1;
-        } else {
-            return 0;
-        }
-    } else { // 3
-        if (!city->trader_figure_ids[0]) {
-            index = 0;
-        } else if (!city->trader_figure_ids[1]) {
-            index = 1;
-        } else if (!city->trader_figure_ids[2]) {
-            index = 2;
-        } else {
-            return 0;
+
+    // Find a slot to hold a trader
+    int max_traders = calc_bound(trade_potential / RESOURCES_TO_TRADER_RATIO + 1, 1, MAX_TRADERS);
+    int index = -1;
+    for (int f = 0; f < max_traders; f++) {
+        if (!city->trader_figure_ids[f]) {
+            index = f;
         }
     }
-
-    if (city->trader_entry_delay > 0) {
-        city->trader_entry_delay--;
+    if (index == -1) {
         return 0;
     }
-    city->trader_entry_delay = city->is_sea_trade ? 30 : 4;
 
     if (city->is_sea_trade) {
         // generate ship
@@ -346,7 +335,7 @@ void empire_city_generate_trader(void)
 
 void empire_city_remove_trader(int city_id, int figure_id)
 {
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < MAX_TRADERS; i++) {
         if (cities[city_id].trader_figure_ids[i] == figure_id) {
             cities[city_id].trader_figure_ids[i] = 0;
         }
@@ -399,7 +388,7 @@ void empire_city_save_state(buffer *buf)
         buffer_write_i16(buf, city->empire_object_id);
         buffer_write_u8(buf, city->is_sea_trade);
         buffer_write_u8(buf, 0);
-        for (int f = 0; f < 3; f++) {
+        for (int f = 0; f < MAX_TRADERS; f++) {
             buffer_write_i16(buf, city->trader_figure_ids[f]);
         }
         for (int p = 0; p < 10; p++) {
@@ -431,7 +420,7 @@ void empire_city_load_state(buffer *buf)
         city->empire_object_id = buffer_read_i16(buf);
         city->is_sea_trade = buffer_read_u8(buf);
         buffer_skip(buf, 1);
-        for (int f = 0; f < 3; f++) {
+        for (int f = 0; f < MAX_TRADERS; f++) {
             city->trader_figure_ids[f] = buffer_read_i16(buf);
         }
         buffer_skip(buf, 10);

--- a/src/empire/city.h
+++ b/src/empire/city.h
@@ -4,7 +4,7 @@
 #include "core/buffer.h"
 #include "game/resource.h"
 
-#define MAX_TRADERS 3
+#define EMPIRE_CITY_MAX_TRADERS 3
 
 typedef struct {
     int in_use;
@@ -18,7 +18,7 @@ typedef struct {
     int trader_entry_delay;
     int empire_object_id;
     int is_sea_trade;
-    int trader_figure_ids[MAX_TRADERS];
+    int trader_figure_ids[EMPIRE_CITY_MAX_TRADERS];
 } empire_city;
 
 void empire_city_clear_all(void);

--- a/src/empire/city.h
+++ b/src/empire/city.h
@@ -4,6 +4,8 @@
 #include "core/buffer.h"
 #include "game/resource.h"
 
+#define MAX_TRADERS 3
+
 typedef struct {
     int in_use;
     int type;
@@ -16,7 +18,7 @@ typedef struct {
     int trader_entry_delay;
     int empire_object_id;
     int is_sea_trade;
-    int trader_figure_ids[3];
+    int trader_figure_ids[MAX_TRADERS];
 } empire_city;
 
 void empire_city_clear_all(void);


### PR DESCRIPTION
Move easy bail-out conditions up so we can deal with the cheaper conditions early
Replace the decision tree to find a free slot with a loop. This allows us to parameterize (need to adjust serialization code before we can really change these values)
Add MAX_TRADERS, SEA_TRADER_DELAY_TICKS and LAND_TRADER DELAY TICKS defines to replace some magic numbers. 