### PR TITLE
A few small tweaks to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ ext/mpg123*
 
 # Asset packer
 /res/asset_packer*/build*/
+/res/asset_packer/.ionide/
 
 # Android
 *.iml
@@ -47,3 +48,7 @@ local.properties
 /android/play-publisher.json
 /android/augustus/src/main/play
 /android/julius/src/main/play
+
+# lib files
+ext/SDL2/*.zip
+ext/SDL2/*.tar.gz


### PR DESCRIPTION
Ignore res/asset_packer/.ionide
Ignore .zip and .tar.gz files from ext/SDL2/ those may be the downloaded packages and we shouldn't check them in