### PR TITLE
Allow elevations to stay at map's edge

### DIFF
--- a/src/map/elevation.c
+++ b/src/map/elevation.c
@@ -2,6 +2,7 @@
 
 #include "map/data.h"
 #include "map/grid.h"
+#include "map/terrain.h"
 
 static grid_u8 elevation;
 
@@ -23,11 +24,12 @@ void map_elevation_clear(void)
 static void fix_cliff_tiles(int grid_offset)
 {
     // reduce elevation when the surrounding tiles are at least 2 lower
+    // treat edges as being equal elevations
     int max = elevation.items[grid_offset] - 1;
-    if (elevation.items[grid_offset + map_grid_delta(-1, 0)] < max ||
-        elevation.items[grid_offset + map_grid_delta(0, -1)] < max ||
-        elevation.items[grid_offset + map_grid_delta(1, 0)] < max ||
-        elevation.items[grid_offset + map_grid_delta(0, 1)] < max) {
+    if ((elevation.items[grid_offset + map_grid_delta(-1, 0)] < max && map_terrain_get(grid_offset + map_grid_delta(-1, 0)) != TERRAIN_MAP_EDGE) ||
+        (elevation.items[grid_offset + map_grid_delta(0, -1)] < max && map_terrain_get(grid_offset + map_grid_delta(0, -1)) != TERRAIN_MAP_EDGE) ||
+        (elevation.items[grid_offset + map_grid_delta(1, 0)] < max && map_terrain_get(grid_offset + map_grid_delta(1, 0)) != TERRAIN_MAP_EDGE) ||
+        (elevation.items[grid_offset + map_grid_delta(0, 1)] < max && map_terrain_get(grid_offset + map_grid_delta(0, 1)) != TERRAIN_MAP_EDGE)) {
         elevation.items[grid_offset]--;
     }
 }

--- a/src/map/image_context.c
+++ b/src/map/image_context.c
@@ -352,7 +352,12 @@ const terrain_image *map_image_context_get_elevation(int grid_offset, int elevat
 {
     int tiles[MAX_TILES];
     for (int i = 0; i < MAX_TILES; i++) {
-        tiles[i] = map_elevation_at(grid_offset + map_grid_direction_delta(i)) >= elevation ? 1 : 0;
+        int target_offset = grid_offset + map_grid_direction_delta(i);
+        if (map_terrain_get(target_offset) == TERRAIN_MAP_EDGE) {
+            tiles[i] = 1;
+        } else {
+            tiles[i] = map_elevation_at(grid_offset + map_grid_direction_delta(i)) >= elevation ? 1 : 0;
+        }
     }
     return get_image(CONTEXT_ELEVATION, tiles);
 }

--- a/src/map/terrain.c
+++ b/src/map/terrain.c
@@ -394,7 +394,7 @@ void map_terrain_init_outside_map(void)
         int y_outside_map = y < y_start || y >= y_start + map_height;
         for (int x = 0; x < GRID_SIZE; x++) {
             if (y_outside_map || x < x_start || x >= x_start + map_width) {
-                terrain_grid.items[x + GRID_SIZE * y] = TERRAIN_TREE | TERRAIN_WATER;
+                terrain_grid.items[x + GRID_SIZE * y] = TERRAIN_MAP_EDGE;
             }
         }
     }

--- a/src/map/terrain.h
+++ b/src/map/terrain.h
@@ -30,7 +30,8 @@ enum {
     TERRAIN_IMPASSABLE_WOLF = 0xd73f,
     TERRAIN_ELEVATION_ROCK = 0x202,
     TERRAIN_ALL = 0xffff,
-    TERRAIN_ORIGINALLY_TREE = 0x10000
+    TERRAIN_ORIGINALLY_TREE = 0x10000,
+    TERRAIN_MAP_EDGE = TERRAIN_TREE | TERRAIN_WATER
 };
 
 int map_terrain_is(int grid_offset, int terrain);


### PR DESCRIPTION
Changes the way elevations are treated at an edge. Vanilla/current behavior forces the cliffs to end at the maps' end. PR changes it, to continue elevated area into black parts of the map. This also allows placing invasion points/entry/exit points at the map's edge. Downsize is possible change of the past maps.

Comparison pic:
![after](https://user-images.githubusercontent.com/59965174/171054352-6e93c68f-f2b2-4371-bcf2-9b7d16916191.png)
.