### PR TITLE
Fix bug where ships would queue up for docks after trading goods at an adjacent dock.

### DIFF
--- a/src/building/dock.c
+++ b/src/building/dock.c
@@ -4,17 +4,17 @@
 #include "city/buildings.h"
 #include "city/resource.h"
 #include "empire/city.h"
+#include "empire/empire.h"
+#include "figure/figure.h"
+#include "figure/trader.h"
+#include "figuretype/trader.h"
+#include "game/resource.h"
 #include "map/figure.h"
 #include "map/grid.h"
 #include "map/routing.h"
+#include "map/routing_data.h"
 #include "map/terrain.h"
 #include "scenario/map.h"
-#include "empire/empire.h"
-#include "figure/trader.h"
-#include "figuretype/trader.h"
-#include "map/routing_data.h"
-#include "game/resource.h"
-#include "figure/figure.h"
 
 #include <string.h>
 

--- a/src/building/dock.c
+++ b/src/building/dock.c
@@ -252,7 +252,7 @@ void building_dock_get_handled_goods(handled_good *handled_goods, int ship_id)
         }
     }
 
-    int next_idx = 0;
+    int next_available_idx = 0;
     // loop through the docks
     for (int i = 0; i < 10; i++) {
         // check and see if the ship has visited this dock
@@ -284,8 +284,8 @@ void building_dock_get_handled_goods(handled_good *handled_goods, int ship_id)
         }
 
         if (!added_handled_good) {
-            // no handled_good found for this road network. use the next available one and add all the resources it accepts
-            handled_good *handled_good = handled_goods + next_idx;
+            // no handled_good found for this road network. use the next available one and add all the resources that the dock accepts
+            handled_good *handled_good = handled_goods + next_available_idx;
             handled_good->road_network_id = dock->road_network_id;
             for (int r = RESOURCE_MIN; r < RESOURCE_MAX; r++) {
                 if (building_distribution_is_good_accepted(r - 1, dock)) {
@@ -293,7 +293,7 @@ void building_dock_get_handled_goods(handled_good *handled_goods, int ship_id)
                 }
             }
             added_handled_good = 1;
-            next_idx++;
+            next_available_idx++;
         }
     }
 }

--- a/src/building/dock.h
+++ b/src/building/dock.h
@@ -6,6 +6,8 @@
 #include "game/resource.h"
 #include "figure/figure.h"
 
+#define MAX_DOCKS 10
+
 typedef enum {
     SHIP_DOCK_REQUEST_1_DOCKING = 1,
     SHIP_DOCK_REQUEST_2_FIRST_QUEUE = 2,
@@ -16,7 +18,7 @@ typedef enum {
 
 typedef struct handled_good {
     unsigned char road_network_id;
-    int goods[RESOURCE_MAX - 1];
+    uint16_t goods;
 } handled_good;
 
 int building_dock_count_idle_dockers(const building *dock);

--- a/src/building/dock.h
+++ b/src/building/dock.h
@@ -3,8 +3,6 @@
 
 #include "building/building.h"
 #include "map/point.h"
-#include "game/resource.h"
-#include "figure/figure.h"
 
 #define MAX_DOCKS 10
 
@@ -15,11 +13,6 @@ typedef enum {
     SHIP_DOCK_REQUEST_6_ANY_QUEUE = 6,
     SHIP_DOCK_REQUEST_7_ANY = 7,
 } ship_dock_request_type;
-
-typedef struct handled_good {
-    unsigned char road_network_id;
-    int goods[RESOURCE_MAX - 1];
-} handled_good;
 
 int building_dock_count_idle_dockers(const building *dock);
 
@@ -48,8 +41,4 @@ int building_dock_can_export_to_ship(building *dock, int ship_id);
 int building_dock_can_trade_with_route(int route_id, int dock_id);
 
 void building_dock_set_can_trade_with_route(int route_id, int dock_id, int can_trade);
-
-void building_dock_get_handled_goods(handled_good *handled_goods, int ship_id);
-
-int building_dock_goods_handled(handled_good *handled_goods, building *dock, figure *ship);
 #endif // BUILDING_DOCK_H

--- a/src/building/dock.h
+++ b/src/building/dock.h
@@ -1,7 +1,6 @@
 #ifndef BUILDING_DOCK_H
 #define BUILDING_DOCK_H
 
-#include <stdbool.h>
 #include "building/building.h"
 #include "map/point.h"
 #include "game/resource.h"
@@ -17,7 +16,7 @@ typedef enum {
 
 typedef struct handled_good {
     unsigned char road_network_id;
-    bool goods[RESOURCE_MAX - 1];
+    int goods[RESOURCE_MAX - 1];
 } handled_good;
 
 int building_dock_count_idle_dockers(const building *dock);
@@ -50,5 +49,5 @@ void building_dock_set_can_trade_with_route(int route_id, int dock_id, int can_t
 
 void building_dock_get_handled_goods(handled_good *handled_goods, int ship_id);
 
-bool building_dock_goods_handled(handled_good *handled_goods, building *dock, figure *ship);
+int building_dock_goods_handled(handled_good *handled_goods, building *dock, figure *ship);
 #endif // BUILDING_DOCK_H

--- a/src/building/dock.h
+++ b/src/building/dock.h
@@ -1,8 +1,11 @@
 #ifndef BUILDING_DOCK_H
 #define BUILDING_DOCK_H
 
+#include <stdbool.h>
 #include "building/building.h"
 #include "map/point.h"
+#include "game/resource.h"
+#include "figure/figure.h"
 
 typedef enum {
     SHIP_DOCK_REQUEST_1_DOCKING = 1,
@@ -11,6 +14,11 @@ typedef enum {
     SHIP_DOCK_REQUEST_6_ANY_QUEUE = 6,
     SHIP_DOCK_REQUEST_7_ANY = 7,
 } ship_dock_request_type;
+
+typedef struct handled_good {
+    unsigned char road_network_id;
+    bool goods[RESOURCE_MAX - 1];
+} handled_good;
 
 int building_dock_count_idle_dockers(const building *dock);
 
@@ -39,4 +47,8 @@ int building_dock_can_export_to_ship(building *dock, int ship_id);
 int building_dock_can_trade_with_route(int route_id, int dock_id);
 
 void building_dock_set_can_trade_with_route(int route_id, int dock_id, int can_trade);
+
+void building_dock_get_handled_goods(handled_good *handled_goods, int ship_id);
+
+bool building_dock_goods_handled(handled_good *handled_goods, building *dock, figure *ship);
 #endif // BUILDING_DOCK_H

--- a/src/building/dock.h
+++ b/src/building/dock.h
@@ -18,7 +18,7 @@ typedef enum {
 
 typedef struct handled_good {
     unsigned char road_network_id;
-    uint16_t goods;
+    int goods[RESOURCE_MAX - 1];
 } handled_good;
 
 int building_dock_count_idle_dockers(const building *dock);

--- a/src/figuretype/trader.c
+++ b/src/figuretype/trader.c
@@ -1038,7 +1038,7 @@ int figure_trader_ship_docked_once_at_dock(figure *ship, int dock_id)
 {
     for (int i = 0; i < MAX_DOCKS; i++) {
         if (dock_id == city_buildings_get_working_dock(i)) {
-            if (figure_trader_ship_docked_once_at_dock_by_num(ship, i)) {
+            if (figure_trader_ship_already_docked_at(ship, i)) {
                 return 1;
             }
         }
@@ -1046,7 +1046,7 @@ int figure_trader_ship_docked_once_at_dock(figure *ship, int dock_id)
     return 0;
 }
 
-int figure_trader_ship_docked_once_at_dock_by_num(figure *ship, int dock_num)
+int figure_trader_ship_already_docked_at(figure *ship, int dock_num)
 {
     return ship->building_id & (1 << dock_num);
 }

--- a/src/figuretype/trader.c
+++ b/src/figuretype/trader.c
@@ -745,7 +745,7 @@ static int record_dock(figure *ship, int dock_id)
     if (dock->data.dock.trade_ship_id != 0 && dock->data.dock.trade_ship_id != ship->id) {
         return 0;
     }
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < MAX_DOCKS; i++) {
         if (dock_id == city_buildings_get_working_dock(i)) {
             ship->building_id |= 1 << i;
             dock->data.dock.trade_ship_id = ship->id;
@@ -1036,14 +1036,19 @@ int figure_trade_sea_trade_units()
 
 int figure_trader_ship_docked_once_at_dock(figure *ship, int dock_id)
 {
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < MAX_DOCKS; i++) {
         if (dock_id == city_buildings_get_working_dock(i)) {
-            if (ship->building_id & 1 << i) {
+            if (figure_trader_ship_docked_once_at_dock_by_num(ship, i)) {
                 return 1;
             }
         }
     }
     return 0;
+}
+
+int figure_trader_ship_docked_once_at_dock_by_num(figure *ship, int dock_num)
+{
+    return ship->building_id & (1 << dock_num);
 }
 
 // if ship is moored, do not forward to another dock unless it has more than one third of capacity available.

--- a/src/figuretype/trader.h
+++ b/src/figuretype/trader.h
@@ -33,6 +33,8 @@ int figure_trade_sea_trade_units();
 
 int figure_trader_ship_docked_once_at_dock(figure *ship, int dock_id);
 
+int figure_trader_ship_docked_once_at_dock_by_num(figure *ship, int dock_num);
+
 int figure_trader_ship_can_queue_for_import(figure *ship);
 
 int figure_trader_ship_can_queue_for_export(figure *ship);

--- a/src/figuretype/trader.h
+++ b/src/figuretype/trader.h
@@ -33,7 +33,7 @@ int figure_trade_sea_trade_units();
 
 int figure_trader_ship_docked_once_at_dock(figure *ship, int dock_id);
 
-int figure_trader_ship_docked_once_at_dock_by_num(figure *ship, int dock_num);
+int figure_trader_ship_already_docked_at(figure *ship, int dock_num);
 
 int figure_trader_ship_can_queue_for_import(figure *ship);
 


### PR DESCRIPTION
In the attached save file, the trade ship on the top left will finish buying weapons and then queue up at the adjacent dock until the ship that's already there leaves. This PR fixes the issue by checking to see if a dock allows importing or exporting any new goods or is on a different road network before sending a ship there.

[Ship Glitch.zip](https://github.com/Keriew/augustus/files/9457880/Ship.Glitch.zip)
