### PR TITLE
Save several translation files with different encoding

### DIFF
--- a/src/translation/japanese.c
+++ b/src/translation/japanese.c
@@ -1,4 +1,4 @@
-#include "translation/common.h"
+﻿#include "translation/common.h"
 #include "translation/translation.h"
 
 static translation_string all_strings[] = {

--- a/src/translation/korean.c
+++ b/src/translation/korean.c
@@ -1,4 +1,4 @@
-#include "translation/common.h"
+﻿#include "translation/common.h"
 #include "translation/translation.h"
 
 static translation_string all_strings[] = {

--- a/src/translation/simplified_chinese.c
+++ b/src/translation/simplified_chinese.c
@@ -1,4 +1,4 @@
-#include "translation/common.h"
+﻿#include "translation/common.h"
 #include "translation/translation.h"
 
 static translation_string all_strings[] = {

--- a/src/translation/traditional_chinese.c
+++ b/src/translation/traditional_chinese.c
@@ -1,4 +1,4 @@
-#include "translation/common.h"
+﻿#include "translation/common.h"
 #include "translation/translation.h"
 
 static translation_string all_strings[] = {


### PR DESCRIPTION
Their current encoding is utf-8 without signature, this causes trouble when system locale is not set to English. The compiler would fail to properly read these files thus fail to build. I am re-saving them as utf-8 with signature (also known as utf-8 with bom).

This problem is specific to eastern asia characters. Here's a brief explanation https://github.com/tfussell/xlnt/issues/460#issuecomment-763584514, and a more detailed article on this https://docs.unrealengine.com/4.27/en-US/ProgrammingAndScripting/ProgrammingWithCPP/UnrealArchitecture/StringHandling/CharacterEncoding/

github does not render the diff reasonably. I did not change any content of these files, but instead re-save them as a different encoding. This solved the build error on my local dev environment.