### PR TITLE
Display plague message in Health advisor if a plagued building is burned down

### DIFF
--- a/src/city/health.c
+++ b/src/city/health.c
@@ -396,6 +396,15 @@ int city_health_get_global_sickness_level(void)
         }
     }
 
+    if (max_sickness_level < MAX_SICKNESS_LEVEL) {
+        for (building *b = building_first_of_type(BUILDING_BURNING_RUIN); b; b = b->next_of_type) {
+            if (b->state != BUILDING_STATE_IN_USE && b->has_plague) {
+                max_sickness_level = MAX_SICKNESS_LEVEL;
+                break;
+            }
+        }
+    }
+
     if (building_number == 0) {
         return SICKNESS_LEVEL_LOW;
     }


### PR DESCRIPTION
Code by Awatibala (dvincent56)

In #660 , we forgot a case: if a house is burned down because of plague ("regular" plague , or sickness = 100 while global health rating < 40), TR_ADVISOR_SICKNESS_LEVEL_PLAGUE should be displayed in the Health Advisor, while the house burns.

![plague_burn](https://user-images.githubusercontent.com/11946570/189546705-ec45b630-c4c2-456a-8e71-68589004d836.png) =
_The plague has come to some unhealthy areas in the city! Citizens fall ill and buildings have been quarantined or burned to prevent the further spread of disease. Available doctors and surgeons have been requisitioned to decontaminate the afflicted places. Action must be taken!_
