### PR TITLE
Don't try to find a path to a destination that can't be reached.

### DIFF
--- a/src/figure/route.c
+++ b/src/figure/route.c
@@ -82,6 +82,7 @@ void figure_route_add(figure *f)
         int can_travel;
         switch (f->terrain_usage) {
             case TERRAIN_USAGE_ENEMY:
+                // check to see if we can reach our destination by going around the city walls
                 can_travel = map_routing_noncitizen_can_travel_over_land(f->x, f->y,
                     f->destination_x, f->destination_y, f->destination_building_id, 5000);
                 if (!can_travel) {

--- a/src/map/routing.c
+++ b/src/map/routing.c
@@ -53,6 +53,7 @@ static struct {
 
 static struct {
     int through_building_id;
+    int dest_building_id;
 } state;
 
 static void reset_fighting_status(void)
@@ -520,7 +521,8 @@ static int callback_travel_noncitizen_land_through_building(int next_offset, int
     if (terrain == NONCITIZEN_0_PASSABLE || terrain == NONCITIZEN_2_CLEARABLE) {
         return 1;
     }
-    if (terrain == NONCITIZEN_1_BUILDING && map_building_at(next_offset) == state.through_building_id) {
+    int map_building_id = map_building_at(next_offset);
+    if (terrain == NONCITIZEN_1_BUILDING && (map_building_id == state.through_building_id || map_building_id == state.dest_building_id)) {
         return 1;
     }
     return 0;
@@ -545,6 +547,8 @@ int map_routing_noncitizen_can_travel_over_land(
     ++stats.enemy_routes_calculated;
     if (only_through_building_id) {
         state.through_building_id = only_through_building_id;
+        // due to formation offsets, the destination building may not be the same as the "through building" (a.k.a. target building)
+        state.dest_building_id = map_building_at(map_grid_offset(dst_x, dst_y));
         route_queue_from_to(src_x, src_y, dst_x, dst_y, 0, callback_travel_noncitizen_land_through_building);
     } else {
         route_queue_from_to(src_x, src_y, dst_x, dst_y, max_tiles, callback_travel_noncitizen_land);

--- a/src/map/routing.c
+++ b/src/map/routing.c
@@ -179,7 +179,7 @@ static inline int distance_left(int x, int y)
 }
 
 static void route_queue_from_to(int src_x, int src_y, int dst_x, int dst_y, int max_tiles,
-    int (*callback)(int next_offset, int dist, int remaining_dist))
+    int (*callback)(int next_offset))
 {
     clear_data();
     distance.dst_x = dst_x;
@@ -187,7 +187,7 @@ static void route_queue_from_to(int src_x, int src_y, int dst_x, int dst_y, int 
     int dest = map_grid_offset(dst_x, dst_y);
     ordered_enqueue(map_grid_offset(src_x, src_y), 1, 0);
     int tiles = 0;
-    if (!valid_offset(dest) || !callback(dest, 1, 0)) {
+    if (!valid_offset(dest) || !callback(dest)) {
         return;
     }
     while (queue.tail) {
@@ -203,7 +203,7 @@ static void route_queue_from_to(int src_x, int src_y, int dst_x, int dst_y, int 
             int next_offset = offset + ROUTE_OFFSETS[i];
             if (valid_offset(next_offset)) {
                 int remaining_dist = distance_left(x + ROUTE_OFFSETS_X[i], y + ROUTE_OFFSETS_Y[i]);
-                if (callback(next_offset, dist, remaining_dist)) {
+                if (callback(next_offset)) {
                     ordered_enqueue(next_offset, dist, remaining_dist);
                 }
             }
@@ -460,7 +460,7 @@ static inline int has_fighting_enemy(int grid_offset)
     return fighting_data.status.items[grid_offset] & 2;
 }
 
-static int callback_travel_citizen_land(int next_offset, int dist, int remaining_dist)
+static int callback_travel_citizen_land(int next_offset)
 {
     if (terrain_land_citizen.items[next_offset] >= 0 && !has_fighting_friendly(next_offset)) {
         return 1;
@@ -475,7 +475,7 @@ int map_routing_citizen_can_travel_over_land(int src_x, int src_y, int dst_x, in
     return distance.determined.items[map_grid_offset(dst_x, dst_y)] != 0;
 }
 
-static int callback_travel_citizen_road_garden(int next_offset, int dist, int remaining_dist)
+static int callback_travel_citizen_road_garden(int next_offset)
 {
     if (terrain_land_citizen.items[next_offset] >= CITIZEN_0_ROAD &&
         terrain_land_citizen.items[next_offset] <= CITIZEN_2_PASSABLE_TERRAIN) {
@@ -496,7 +496,7 @@ int map_routing_citizen_can_travel_over_road_garden(int src_x, int src_y, int ds
     return distance.determined.items[dst_offset] != 0;
 }
 
-static int callback_travel_walls(int next_offset, int dist, int remaining_dist)
+static int callback_travel_walls(int next_offset)
 {
     if (terrain_walls.items[next_offset] >= WALL_0_PASSABLE &&
         terrain_walls.items[next_offset] <= 2) {
@@ -512,7 +512,7 @@ int map_routing_can_travel_over_walls(int src_x, int src_y, int dst_x, int dst_y
     return distance.determined.items[map_grid_offset(dst_x, dst_y)] != 0;
 }
 
-static int callback_travel_noncitizen_land_through_building(int next_offset, int dist, int remaining_dist)
+static int callback_travel_noncitizen_land_through_building(int next_offset)
 {
     if (has_fighting_enemy(next_offset)) {
         return 0;
@@ -528,7 +528,7 @@ static int callback_travel_noncitizen_land_through_building(int next_offset, int
     return 0;
 }
 
-static int callback_travel_noncitizen_land(int next_offset, int dist, int remaining_dist)
+static int callback_travel_noncitizen_land(int next_offset)
 {
     if (has_fighting_enemy(next_offset)) {
         return 0;
@@ -556,7 +556,7 @@ int map_routing_noncitizen_can_travel_over_land(
     return distance.determined.items[map_grid_offset(dst_x, dst_y)] != 0;
 }
 
-static int callback_travel_noncitizen_through_everything(int next_offset, int dist, int remaining_dist)
+static int callback_travel_noncitizen_through_everything(int next_offset)
 {
     if (terrain_land_noncitizen.items[next_offset] >= NONCITIZEN_0_PASSABLE) {
         return 1;


### PR DESCRIPTION
This significantly improves performance when getting attacked by large armies of ornery Carthaginians, as seen in this save from @Keriew.

Enemies do a first-pass check to see if they can reach their target building without going through any structures, the idea being we want them to try to go around walls. Unfortunately due to their formation offset, their destination is often unreachable as it is a building adjacent to their target. I've added a separate check to see if the building at the next tile is the one at their destination and also added an additional check to ensure that a destination is reachable before attempting to calculate a path there.

[0_0_0_military_crash_test.zip](https://github.com/Keriew/augustus/files/9595742/0_0_0_military_crash_test.zip)
