### PR TITLE
Possible fix for bug where grand temples would believe they already had architects.

### DIFF
--- a/src/building/building_state.c
+++ b/src/building/building_state.c
@@ -345,6 +345,9 @@ static void read_type_data(buffer *buf, building *b, int version)
         for (int i = 0; i < RESOURCE_MAX; i++) {
             b->data.monument.resources_needed[i] = buffer_read_i16(buf);
         }
+        if (b->data.monument.resources_needed[RESOURCE_NONE] < 0) {
+            b->data.monument.resources_needed[RESOURCE_NONE] = 1;
+        }
         b->data.monument.upgrades = buffer_read_i32(buf);
         b->data.monument.progress = buffer_read_i16(buf);
         b->data.monument.phase = buffer_read_i16(buf);

--- a/src/building/monument.c
+++ b/src/building/monument.c
@@ -499,7 +499,7 @@ int building_monument_needs_resources(building *b)
         return 0;
     }
     for (int resource = RESOURCE_MIN; resource < RESOURCE_MAX; resource++) {
-        if (b->data.monument.resources_needed[resource]) {
+        if (b->data.monument.resources_needed[resource] > 0) {
             return 1;
         }
     }

--- a/src/figuretype/workcamp.c
+++ b/src/figuretype/workcamp.c
@@ -289,18 +289,19 @@ void figure_workcamp_engineer_action(figure *f)
             break;
         case FIGURE_ACTION_207_WORK_CAMP_ARCHITECT_GOING_TO_MONUMENT:
             figure_movement_move_ticks(f, 1);
-            if (f->direction == DIR_FIGURE_AT_DESTINATION || f->direction == DIR_FIGURE_LOST) {
-                f->action_state = FIGURE_ACTION_208_WORK_CAMP_ARCHITECT_WORKING_ON_MONUMENT;
-                monument = building_get(f->destination_building_id);
-                if (!building_monument_access_point(monument, &dst) || b->data.monument.phase == MONUMENT_FINISHED) {
-                    f->state = FIGURE_STATE_DEAD;
+            monument = building_get(f->destination_building_id);
+            if (monument->state == BUILDING_STATE_UNUSED || !building_monument_access_point(monument, &dst) || b->data.monument.phase == MONUMENT_FINISHED) {
+                f->state = FIGURE_STATE_DEAD;
+            } else {
+                if (f->direction == DIR_FIGURE_AT_DESTINATION || f->direction == DIR_FIGURE_LOST) {
+                    f->action_state = FIGURE_ACTION_208_WORK_CAMP_ARCHITECT_WORKING_ON_MONUMENT;
+                    figure_movement_set_cross_country_destination(f, dst.x, dst.y);
+                    f->wait_ticks = 1;
+                } else if (f->direction == DIR_FIGURE_REROUTE) {
+                    figure_route_remove(f);
                 }
-                figure_movement_set_cross_country_destination(f, dst.x, dst.y);
-                f->wait_ticks = 1;
-            } else if (f->direction == DIR_FIGURE_REROUTE) {
-                figure_route_remove(f);
+                figure_image_update(f, image_group(GROUP_FIGURE_ENGINEER));
             }
-            figure_image_update(f, image_group(GROUP_FIGURE_ENGINEER));
             break;
         case FIGURE_ACTION_208_WORK_CAMP_ARCHITECT_WORKING_ON_MONUMENT:
             figure_image_update(f, image_group(GROUP_FIGURE_ENGINEER));


### PR DESCRIPTION
[bugged_GT.zip](https://github.com/Keriew/augustus/files/9769943/bugged_GT.zip)

The above save has a bug where the grand temple to Venus won't finish because it believes it has received 3 architects already.

I added some code in this PR that will at least correct the issue for existing saves where the number of required architects has become negative. However doing this revealed another bug where if you delete the two grand temples and create two new ones, the architect heading to the grand temple of Venus will arrive and then travel cross country to the other new temple and give it an architect resource for its current phase, putting it into a similarly broken state. I've added a check in the architect movement code to tell them to die if their destination is gone.

Finally I've changed the building_monument_needs_resources() check to only care if resources are greater than 0 to try to avoid this situation in the future. I'm still not really sure how this save got negative architects in the first place though.