### PR TITLE
Magical forest donkeys

### DIFF
--- a/src/figure/movement.c
+++ b/src/figure/movement.c
@@ -424,13 +424,12 @@ void figure_movement_move_ticks_tower_sentry(figure *f, int num_ticks)
 
 void figure_movement_follow_ticks(figure *f, int num_ticks)
 {
-    int terrain = map_terrain_get(map_grid_offset(f->x, f->y));
-    if (terrain & TERRAIN_HIGHWAY) {
-        num_ticks *= 2;
-    }
     const figure *leader = figure_get(f->leading_figure_id);
     if (f->x == f->source_x && f->y == f->source_y) {
         f->is_ghost = 1;
+    }
+    if (map_terrain_is(map_grid_offset(leader->x, leader->y), TERRAIN_HIGHWAY)) {
+        num_ticks *= 2;
     }
     while (num_ticks > 0) {
         num_ticks--;
@@ -464,16 +463,15 @@ void figure_movement_follow_ticks_with_percentage(figure* f, int num_ticks, int 
         num_ticks--;
     }
     f->progress_to_next_tick = (char) progress;
-    
-    int terrain = map_terrain_get(map_grid_offset(f->x, f->y));
-    if (terrain & TERRAIN_HIGHWAY) {
-        num_ticks *= 2;
-    }
 
     const figure* leader = figure_get(f->leading_figure_id);
     if (f->x == f->source_x && f->y == f->source_y) {
         f->is_ghost = 1;
     }
+    if (map_terrain_is(map_grid_offset(leader->x, leader->y), TERRAIN_HIGHWAY)) {
+        num_ticks *= 2;
+    }
+
     while (num_ticks > 0) {
         num_ticks--;
         f->progress_on_tile++;


### PR DESCRIPTION
Make followers use the same speed bonus as the leader in an attempt to reduce the number of prances magical forest donkeys need.