### PR TITLE
Fix bug where having too many sprites on the same tile would result in them drawing in random locations.

### DIFF
--- a/src/widget/city_figure.c
+++ b/src/widget/city_figure.c
@@ -217,13 +217,14 @@ static void adjust_pixel_offset(const figure *f, int *pixel_x, int *pixel_y)
         if (f->figures_on_same_tile_index && f->type != FIGURE_BALLISTA) {
             // an attempt to not let people walk through each other
             static const int BUSY_ROAD_X_OFFSETS[] = {
-                0, 8, 8, -8, -8, 0, 16, 0, -16, 8, -8, 16, -16, 16, -16, 8, -8, 0, 24, 0, -24, 0, 0, 0
+                0, 8, 8, -8, -8, 0, 16, 0, -16, 8, -8, 16, -16, 16, -16, 8, -8, 0, 24, 0, -24
             };
             static const int BUSY_ROAD_Y_OFFSETS[] = {
-                0, 0, 8, 8, -8, -16, 0, 16, 0, -16, 16, 8, -8, -8, 8, 16, -16, -24, 0, 24, 0, 0, 0, 0
+                0, 0, 8, 8, -8, -16, 0, 16, 0, -16, 16, 8, -8, -8, 8, 16, -16, -24, 0, 24, 0
             };
-            x_offset += BUSY_ROAD_X_OFFSETS[f->figures_on_same_tile_index];
-            y_offset += BUSY_ROAD_Y_OFFSETS[f->figures_on_same_tile_index];
+            static const int BUSY_ROAD_OFFSET_LEN = 21;
+            x_offset += BUSY_ROAD_X_OFFSETS[f->figures_on_same_tile_index % BUSY_ROAD_OFFSET_LEN];
+            y_offset += BUSY_ROAD_Y_OFFSETS[f->figures_on_same_tile_index % BUSY_ROAD_OFFSET_LEN];
         }
     }
 


### PR DESCRIPTION
Reported by Marek. Test save file attached.
[enemy_sprite_bug.zip](https://github.com/Keriew/augustus/files/9995651/enemy_sprite_bug.zip)
