### PR TITLE
Improve pathfinding calculations across diagonals.

### DIFF
--- a/src/figure/formation_enemy.c
+++ b/src/figure/formation_enemy.c
@@ -331,7 +331,7 @@ int formation_enemy_move_formation_to(const formation *m, int x, int y, int *x_t
             formation_layout_position_x(m->layout, i),
             formation_layout_position_y(m->layout, i)) - base_offset;
     }
-    map_routing_noncitizen_can_travel_over_land(x, y, -1, -1, 0, 600);
+    map_routing_noncitizen_can_travel_over_land(x, y, -1, -1, 8, 0, 600);
     for (int r = 0; r <= 10; r++) {
         int x_min, y_min, x_max, y_max;
         map_grid_get_area(x, y, 1, r, &x_min, &y_min, &x_max, &y_max);
@@ -581,7 +581,7 @@ static void update_enemy_formation(formation *m, int *roman_distance)
         army->home_y = m->y_home;
         army->layout = m->layout;
         *roman_distance = 0;
-        map_routing_noncitizen_can_travel_over_land(m->x_home, m->y_home, -2, -2, 100000, 300);
+        map_routing_noncitizen_can_travel_over_land(m->x_home, m->y_home, -2, -2, 8, 100000, 300);
         int x_tile, y_tile;
         if (map_soldier_strength_get_max(m->x_home, m->y_home, 16, &x_tile, &y_tile)) {
             *roman_distance = 1;

--- a/src/figure/route.c
+++ b/src/figure/route.c
@@ -84,51 +84,51 @@ void figure_route_add(figure *f)
             case TERRAIN_USAGE_ENEMY:
                 // check to see if we can reach our destination by going around the city walls
                 can_travel = map_routing_noncitizen_can_travel_over_land(f->x, f->y,
-                    f->destination_x, f->destination_y, f->destination_building_id, 5000);
+                    f->destination_x, f->destination_y, direction_limit, f->destination_building_id, 5000);
                 if (!can_travel) {
                     can_travel = map_routing_noncitizen_can_travel_over_land(f->x, f->y,
-                        f->destination_x, f->destination_y, 0, 25000);
+                        f->destination_x, f->destination_y, direction_limit, 0, 25000);
                     if (!can_travel) {
                         can_travel = map_routing_noncitizen_can_travel_through_everything(
-                            f->x, f->y, f->destination_x, f->destination_y);
+                            f->x, f->y, f->destination_x, f->destination_y, direction_limit);
                     }
                 }
                 break;
             case TERRAIN_USAGE_WALLS:
                 can_travel = map_routing_can_travel_over_walls(f->x, f->y,
-                    f->destination_x, f->destination_y);
+                    f->destination_x, f->destination_y, 4);
                 break;
             case TERRAIN_USAGE_ANIMAL:
                 can_travel = map_routing_noncitizen_can_travel_over_land(f->x, f->y,
-                    f->destination_x, f->destination_y, -1, 5000);
+                    f->destination_x, f->destination_y, direction_limit, -1, 5000);
                 break;
             case TERRAIN_USAGE_PREFER_ROADS:
                 can_travel = map_routing_citizen_can_travel_over_road_garden(f->x, f->y,
-                    f->destination_x, f->destination_y);
+                    f->destination_x, f->destination_y, direction_limit);
                 if (!can_travel) {
                     can_travel = map_routing_citizen_can_travel_over_land(f->x, f->y,
-                        f->destination_x, f->destination_y);
+                        f->destination_x, f->destination_y, direction_limit);
                 }
                 break;
             case TERRAIN_USAGE_ROADS:
                 can_travel = map_routing_citizen_can_travel_over_road_garden(f->x, f->y,
-                    f->destination_x, f->destination_y);
+                    f->destination_x, f->destination_y, direction_limit);
                 break;
             case TERRAIN_USAGE_PREFER_ROADS_HIGHWAY:
                 can_travel = map_routing_citizen_can_travel_over_road_garden_highway(f->x, f->y,
-                    f->destination_x, f->destination_y);
+                    f->destination_x, f->destination_y, direction_limit);
                 if (!can_travel) {
                     can_travel = map_routing_citizen_can_travel_over_land(f->x, f->y,
-                        f->destination_x, f->destination_y);
+                        f->destination_x, f->destination_y, direction_limit);
                 }
                 break;
             case TERRAIN_USAGE_ROADS_HIGHWAY:
                 can_travel = map_routing_citizen_can_travel_over_road_garden_highway(f->x, f->y,
-                    f->destination_x, f->destination_y);
+                    f->destination_x, f->destination_y, direction_limit);
                 break;
             default:
                 can_travel = map_routing_citizen_can_travel_over_land(f->x, f->y,
-                    f->destination_x, f->destination_y);
+                    f->destination_x, f->destination_y, direction_limit);
                 break;
         }
         if (can_travel) {

--- a/src/map/routing.c
+++ b/src/map/routing.c
@@ -220,11 +220,7 @@ static void route_queue_from_to(int src_x, int src_y, int dst_x, int dst_y, int 
             int next_offset = offset + ROUTE_OFFSETS[i];
             int remaining_dist = distance_left(x + ROUTE_OFFSETS_X[i], y + ROUTE_OFFSETS_Y[i]);
             int dist = 2 + distance.determined.items[offset];
-            // make diagonals less favorable
-            if (i >= 4) {
-                dist++;
-            }
-            if (receive_highway_bonus(offset, i)) {
+            if (receive_highway_bonus(next_offset, i)) {
                 dist--;
             }
             if (valid_offset(next_offset, dist) && callback(offset, next_offset, i)) {

--- a/src/map/routing.c
+++ b/src/map/routing.c
@@ -31,6 +31,10 @@ static const int HIGHWAY_DIRECTIONS[] = {
     TERRAIN_HIGHWAY_BOTTOM_LEFT | TERRAIN_HIGHWAY_BOTTOM_RIGHT, // right
     TERRAIN_HIGHWAY_TOP_LEFT | TERRAIN_HIGHWAY_BOTTOM_LEFT, // down
     TERRAIN_HIGHWAY_TOP_LEFT | TERRAIN_HIGHWAY_TOP_RIGHT, // left
+    0,
+    0,
+    0,
+    0
 };
 
 static map_routing_distance_grid distance;
@@ -212,10 +216,14 @@ static void route_queue_from_to(int src_x, int src_y, int dst_x, int dst_y, int 
         int x = map_grid_offset_to_x(offset);
         int y = map_grid_offset_to_y(offset);
         distance.possible.items[offset] = 1;
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < 8; i++) {
             int next_offset = offset + ROUTE_OFFSETS[i];
             int remaining_dist = distance_left(x + ROUTE_OFFSETS_X[i], y + ROUTE_OFFSETS_Y[i]);
             int dist = 2 + distance.determined.items[offset];
+            // make diagonals less favorable
+            if (i >= 4) {
+                dist++;
+            }
             if (receive_highway_bonus(offset, i)) {
                 dist--;
             }

--- a/src/map/routing.c
+++ b/src/map/routing.c
@@ -199,7 +199,7 @@ static int receive_highway_bonus(int offset, int direction)
     return 0;
 }
 
-static void route_queue_from_to(int src_x, int src_y, int dst_x, int dst_y, int max_tiles,
+static void route_queue_from_to(int src_x, int src_y, int dst_x, int dst_y, int num_directions, int max_tiles,
     int (*callback)(int offset, int next_offset, int direction))
 {
     clear_data();
@@ -216,7 +216,7 @@ static void route_queue_from_to(int src_x, int src_y, int dst_x, int dst_y, int 
         int x = map_grid_offset_to_x(offset);
         int y = map_grid_offset_to_y(offset);
         distance.possible.items[offset] = 1;
-        for (int i = 0; i < 8; i++) {
+        for (int i = 0; i < num_directions; i++) {
             int next_offset = offset + ROUTE_OFFSETS[i];
             int remaining_dist = distance_left(x + ROUTE_OFFSETS_X[i], y + ROUTE_OFFSETS_Y[i]);
             int dist = 2 + distance.determined.items[offset];
@@ -558,10 +558,10 @@ static int callback_travel_citizen_land(int offset, int next_offset, int directi
     return 0;
 }
 
-int map_routing_citizen_can_travel_over_land(int src_x, int src_y, int dst_x, int dst_y)
+int map_routing_citizen_can_travel_over_land(int src_x, int src_y, int dst_x, int dst_y, int num_directions)
 {
     ++stats.total_routes_calculated;
-    route_queue_from_to(src_x, src_y, dst_x, dst_y, 0, callback_travel_citizen_land);
+    route_queue_from_to(src_x, src_y, dst_x, dst_y, num_directions, 0, callback_travel_citizen_land);
     return distance.determined.items[map_grid_offset(dst_x, dst_y)] != 0;
 }
 
@@ -574,7 +574,7 @@ static int callback_travel_citizen_road_garden(int offset, int next_offset, int 
     return 0;
 }
 
-int map_routing_citizen_can_travel_over_road_garden(int src_x, int src_y, int dst_x, int dst_y)
+int map_routing_citizen_can_travel_over_road_garden(int src_x, int src_y, int dst_x, int dst_y, int num_directions)
 {
     int dst_offset = map_grid_offset(dst_x, dst_y);
     if (terrain_land_citizen.items[dst_offset] != CITIZEN_0_ROAD &&
@@ -582,7 +582,7 @@ int map_routing_citizen_can_travel_over_road_garden(int src_x, int src_y, int ds
         return 0;
     }
     ++stats.total_routes_calculated;
-    route_queue_from_to(src_x, src_y, dst_x, dst_y, 0, callback_travel_citizen_road_garden);
+    route_queue_from_to(src_x, src_y, dst_x, dst_y, num_directions, 0, callback_travel_citizen_road_garden);
     return distance.determined.items[dst_offset] != 0;
 }
 
@@ -595,7 +595,7 @@ static int callback_travel_citizen_road_garden_highway(int offset, int next_offs
     return 0;
 }
 
-int map_routing_citizen_can_travel_over_road_garden_highway(int src_x, int src_y, int dst_x, int dst_y)
+int map_routing_citizen_can_travel_over_road_garden_highway(int src_x, int src_y, int dst_x, int dst_y, int num_directions)
 {
     int dst_offset = map_grid_offset(dst_x, dst_y);
     if (terrain_land_citizen.items[dst_offset] < CITIZEN_0_ROAD ||
@@ -603,7 +603,7 @@ int map_routing_citizen_can_travel_over_road_garden_highway(int src_x, int src_y
         return 0;
     }
     ++stats.total_routes_calculated;
-    route_queue_from_to(src_x, src_y, dst_x, dst_y, 0, callback_travel_citizen_road_garden_highway);
+    route_queue_from_to(src_x, src_y, dst_x, dst_y, num_directions, 0, callback_travel_citizen_road_garden_highway);
     return distance.determined.items[dst_offset] != 0;
 }
 
@@ -616,10 +616,10 @@ static int callback_travel_walls(int offset, int next_offset, int direction)
     return 0;
 }
 
-int map_routing_can_travel_over_walls(int src_x, int src_y, int dst_x, int dst_y)
+int map_routing_can_travel_over_walls(int src_x, int src_y, int dst_x, int dst_y, int num_directions)
 {
     ++stats.total_routes_calculated;
-    route_queue_from_to(src_x, src_y, dst_x, dst_y, 0, callback_travel_walls);
+    route_queue_from_to(src_x, src_y, dst_x, dst_y, num_directions, 0, callback_travel_walls);
     return distance.determined.items[map_grid_offset(dst_x, dst_y)] != 0;
 }
 
@@ -652,7 +652,8 @@ static int callback_travel_noncitizen_land(int offset, int next_offset, int dire
 }
 
 int map_routing_noncitizen_can_travel_over_land(
-    int src_x, int src_y, int dst_x, int dst_y, int only_through_building_id, int max_tiles)
+    int src_x, int src_y, int dst_x, int dst_y, int num_directions, int only_through_building_id, int max_tiles
+)
 {
     ++stats.total_routes_calculated;
     ++stats.enemy_routes_calculated;
@@ -660,9 +661,9 @@ int map_routing_noncitizen_can_travel_over_land(
         state.through_building_id = only_through_building_id;
         // due to formation offsets, the destination building may not be the same as the "through building" (a.k.a. target building)
         state.dest_building_id = map_building_at(map_grid_offset(dst_x, dst_y));
-        route_queue_from_to(src_x, src_y, dst_x, dst_y, 0, callback_travel_noncitizen_land_through_building);
+        route_queue_from_to(src_x, src_y, dst_x, dst_y, num_directions, 0, callback_travel_noncitizen_land_through_building);
     } else {
-        route_queue_from_to(src_x, src_y, dst_x, dst_y, max_tiles, callback_travel_noncitizen_land);
+        route_queue_from_to(src_x, src_y, dst_x, dst_y, num_directions, max_tiles, callback_travel_noncitizen_land);
     }
     return distance.determined.items[map_grid_offset(dst_x, dst_y)] != 0;
 }
@@ -675,10 +676,10 @@ static int callback_travel_noncitizen_through_everything(int offset, int next_of
     return 0;
 }
 
-int map_routing_noncitizen_can_travel_through_everything(int src_x, int src_y, int dst_x, int dst_y)
+int map_routing_noncitizen_can_travel_through_everything(int src_x, int src_y, int dst_x, int dst_y, int num_directions)
 {
     ++stats.total_routes_calculated;
-    route_queue_from_to(src_x, src_y, dst_x, dst_y, 0, callback_travel_noncitizen_through_everything);
+    route_queue_from_to(src_x, src_y, dst_x, dst_y, num_directions, 0, callback_travel_noncitizen_through_everything);
     return distance.determined.items[map_grid_offset(dst_x, dst_y)] != 0;
 }
 

--- a/src/map/routing.h
+++ b/src/map/routing.h
@@ -31,14 +31,14 @@ void map_routing_delete_first_wall_or_aqueduct(int x, int y);
 
 int map_routing_distance(int grid_offset);
 
-int map_routing_citizen_can_travel_over_land(int src_x, int src_y, int dst_x, int dst_y);
-int map_routing_citizen_can_travel_over_road_garden(int src_x, int src_y, int dst_x, int dst_y);
-int map_routing_citizen_can_travel_over_road_garden_highway(int src_x, int src_y, int dst_x, int dst_y);
-int map_routing_can_travel_over_walls(int src_x, int src_y, int dst_x, int dst_y);
+int map_routing_citizen_can_travel_over_land(int src_x, int src_y, int dst_x, int dst_y, int num_directions);
+int map_routing_citizen_can_travel_over_road_garden(int src_x, int src_y, int dst_x, int dst_y, int num_directions);
+int map_routing_citizen_can_travel_over_road_garden_highway(int src_x, int src_y, int dst_x, int dst_y, int num_directions);
+int map_routing_can_travel_over_walls(int src_x, int src_y, int dst_x, int dst_y, int num_directions);
 
 int map_routing_noncitizen_can_travel_over_land(
-    int src_x, int src_y, int dst_x, int dst_y, int only_through_building_id, int max_tiles);
-int map_routing_noncitizen_can_travel_through_everything(int src_x, int src_y, int dst_x, int dst_y);
+    int src_x, int src_y, int dst_x, int dst_y, int num_directions, int only_through_building_id, int max_tiles);
+int map_routing_noncitizen_can_travel_through_everything(int src_x, int src_y, int dst_x, int dst_y, int num_directions);
 
 void map_routing_block(int x, int y, int size);
 

--- a/src/map/routing_path.c
+++ b/src/map/routing_path.c
@@ -46,13 +46,29 @@ static void adjust_tile_in_direction(int direction, int *x, int *y, int *grid_of
     *grid_offset += map_grid_direction_delta(direction);
 }
 
+static int is_equal_distance_but_better_direction(int distance, int next_distance, int direction, int next_direction)
+{
+    if (next_distance != distance) {
+        return 0;
+    } else if (direction == -1) {
+        return 1;
+    // prefer going in "straight" directions as opposed to diagonals if the distances are equal.
+    // this helps prevent units from zig-zagging instead of moving in a straight line and makes
+    // up for the removal of the general_direction calculation, which tended to make unit movement
+    // look weird as units would try to move directly towards their destination even if there was
+    // an obstacle in the way.
+    } else if (direction % 2 == 1 && next_direction % 2 == 0) {
+        return 1;
+    }
+    return 0;
+}
+
 static int next_is_better(
     int base_distance,
     int distance,
     int next_distance,
     int direction,
     int next_direction,
-    int general_direction,
     int is_highway,
     int next_is_highway
 )
@@ -64,7 +80,7 @@ static int next_is_better(
         return 0;
     } else if (next_distance < distance) {
         return 1;
-    } else if (next_distance == distance && (next_direction == general_direction || direction == -1)) {
+    } else if (is_equal_distance_but_better_direction(distance, next_distance, direction, next_direction)) {
         return 1;
     }
     return 0;
@@ -90,13 +106,12 @@ int map_routing_get_path(uint8_t *path, int src_x, int src_y, int dst_x, int dst
         distance = base_distance;
         int direction = -1;
         int is_highway = 0;
-        int general_direction = calc_general_direction(x, y, src_x, src_y);
         for (int next_direction = 0; next_direction < 8; next_direction += step) {
             if (next_direction != last_direction) {
                 int next_offset = grid_offset + map_grid_direction_delta(next_direction);
                 int next_distance = map_routing_distance(next_offset);
                 int next_is_highway = map_terrain_is(next_offset, TERRAIN_HIGHWAY);
-                if (next_distance && next_is_better(base_distance, distance, next_distance, direction, next_direction, general_direction, is_highway, next_is_highway)) {
+                if (next_distance && next_is_better(base_distance, distance, next_distance, direction, next_direction, is_highway, next_is_highway)) {
                     distance = next_distance;
                     direction = next_direction;
                     is_highway = next_is_highway;


### PR DESCRIPTION
The pathfinder in the core game does not take diagonals into account correctly as it only looks in 4 directions rather than 8. This means that each diagonal counts for two points rather than one. It's most noticeable when asking a legion to move across terrain with a diagonal route and a straight route, as they will often pick the straight route even if the diagonal would allow them to reach their destination more quickly.