### PR TITLE
Fix bug where spawning several invaders from the cheat console could result in out of bounds.

### DIFF
--- a/src/figure/formation_enemy.c
+++ b/src/figure/formation_enemy.c
@@ -81,7 +81,8 @@ static const int RIOTER_ATTACK_PRIORITY[29] = {
     BUILDING_HOUSE_LARGE_VILLA,
 };
 
-static const int LAYOUT_ORIENTATION_OFFSETS[13][4][40] = {
+#define NUM_LAYOUT_FORMATIONS 40
+static const int LAYOUT_ORIENTATION_OFFSETS[13][4][NUM_LAYOUT_FORMATIONS] = {
     {
         {0, 0, -3, 0, 3, 0, -8, 0, 8, 0, -3, 8, 3, 8, 0},
         {0, 0, 0, -3, 0, 3, 0, -8, 0, 8, 8, -3, 8, 3, 0},
@@ -393,6 +394,14 @@ static void mars_kill_enemies(void)
     city_message_post(1, MESSAGE_SPIRIT_OF_MARS, 0, grid_offset);
 }
 
+static void get_layout_orientation_offset(const enemy_army *army, const formation *m, int *x_offset, int *y_offset)
+{
+    int layout = army->layout;
+    int legion_index_offset = (2 * m->enemy_legion_index) % NUM_LAYOUT_FORMATIONS;
+    *x_offset = LAYOUT_ORIENTATION_OFFSETS[layout][m->orientation / 2][legion_index_offset];
+    *y_offset = LAYOUT_ORIENTATION_OFFSETS[layout][m->orientation / 2][legion_index_offset + 1];
+}
+
 static void update_enemy_movement(formation *m, int roman_distance)
 {
     const enemy_army *army = enemy_army_get(m->invasion_id);
@@ -504,20 +513,20 @@ static void update_enemy_movement(formation *m, int roman_distance)
         }
     } else if (regroup) {
         int layout = army->layout;
-        int x_offset = LAYOUT_ORIENTATION_OFFSETS[layout][m->orientation / 2][2 * m->enemy_legion_index] +
-            army->home_x;
-        int y_offset = LAYOUT_ORIENTATION_OFFSETS[layout][m->orientation / 2][2 * m->enemy_legion_index + 1] +
-            army->home_y;
+        int x_offset, y_offset;
+        get_layout_orientation_offset(army, m, &x_offset, &y_offset);
+        x_offset += army->home_x;
+        y_offset += army->home_y;
         int x_tile, y_tile;
         if (formation_enemy_move_formation_to(m, x_offset, y_offset, &x_tile, &y_tile)) {
             formation_set_destination(m, x_tile, y_tile);
         }
     } else if (advance) {
         int layout = army->layout;
-        int x_offset = LAYOUT_ORIENTATION_OFFSETS[layout][m->orientation / 2][2 * m->enemy_legion_index] +
-            army->destination_x;
-        int y_offset = LAYOUT_ORIENTATION_OFFSETS[layout][m->orientation / 2][2 * m->enemy_legion_index + 1] +
-            army->destination_y;
+        int x_offset, y_offset;
+        get_layout_orientation_offset(army, m, &x_offset, &y_offset);
+        x_offset += army->destination_x;
+        y_offset += army->destination_y;
         int x_tile, y_tile;
         if (formation_enemy_move_formation_to(m, x_offset, y_offset, &x_tile, &y_tile)) {
             formation_set_destination(m, x_tile, y_tile);


### PR DESCRIPTION
[0_0_0_military_crash_test.zip](https://github.com/Keriew/augustus/files/10201369/0_0_0_military_crash_test.zip)

Save file attached. This one is a bit more of an edge case as you have to use the cheat console and spawn many invasions to even hit the issue, but @Keriew did manage to accidentally do it. Since Julius doesn't seem to have a cheat command for spawning enemy invasions, the issue can't occur there.

Also...random C question here. LAYOUT_ORIENTATION_OFFSETS is declared as having 40 elements in each array, but most arrays only have 15. Are the remaining elements set to 0 or are they random? I didn't change them because I didn't know if that was a bug or a quirk of C programming, but if they can get random values then the issue isn't quite fixed yet.