### PR TITLE
Change aqueduct routing to use more robust map_can_place_aqueduct_on_highway() check.

### DIFF
--- a/src/map/road_aqueduct.c
+++ b/src/map/road_aqueduct.c
@@ -176,18 +176,22 @@ static int is_highway(int x, int y, int check_routing)
     return 0;
 }
 
-static int is_aqueduct(int x, int y)
+static int is_aqueduct(int x, int y, int check_routing)
 {
     int grid_offset = map_grid_offset(x, y);
-    if (map_grid_is_valid_offset(grid_offset) && map_terrain_is(grid_offset, TERRAIN_AQUEDUCT)) {
+    if (!map_grid_is_valid_offset(grid_offset)) {
+        return 0;
+    } else if (map_terrain_is(grid_offset, TERRAIN_AQUEDUCT)) {
+        return 1;
+    } else if (check_routing && map_routing_distance(grid_offset) > 0) {
         return 1;
     }
     return 0;
 }
 
-static int is_highway_and_aqueduct(int x, int y, int check_highway_routing)
+static int is_highway_and_aqueduct(int x, int y, int check_highway_routing, int check_aqueduct_routing)
 {
-    if (is_highway(x, y, check_highway_routing) && is_aqueduct(x, y)) {
+    if (is_highway(x, y, check_highway_routing) && is_aqueduct(x, y, check_aqueduct_routing)) {
         return 1;
     }
     return 0;
@@ -195,21 +199,21 @@ static int is_highway_and_aqueduct(int x, int y, int check_highway_routing)
 
 // check to see if placing an aqueduct here would create an aqueduct corner on a highway
 // note: this tile does NOT need to be on a highway to create a corner on one
-static int aqueduct_placement_creates_corner(int x, int y, int corner_x, int corner_y)
+static int aqueduct_placement_creates_corner(int x, int y, int corner_x, int corner_y, int check_aqueduct_routing)
 {
-    if (!is_highway_and_aqueduct(corner_x, corner_y, 0)) {
+    if (!is_highway_and_aqueduct(corner_x, corner_y, 0, check_aqueduct_routing)) {
         return 0;
     }
     int c1x, c1y, c2x, c2y;
     map_grid_get_corner_tiles(x, y, corner_x, corner_y, &c1x, &c1y, &c2x, &c2y);
-    if (is_aqueduct(c1x, c1y) || is_aqueduct(c2x, c2y)) {
+    if (is_aqueduct(c1x, c1y, check_aqueduct_routing) || is_aqueduct(c2x, c2y, check_aqueduct_routing)) {
         return 1;
     }
     return 0;
 }
 
 // check to see if placing an aqueduct here would create a line (at least two aqueduct tiles) along a highway
-static int aqueduct_highway_line(int x, int y, int is_check_x, int check_highway_routing)
+static int aqueduct_highway_line(int x, int y, int is_check_x, int check_highway_routing, int check_aqueduct_routing)
 {
     int x_offs = 1;
     int y_offs = 0;
@@ -217,8 +221,8 @@ static int aqueduct_highway_line(int x, int y, int is_check_x, int check_highway
         x_offs = 0;
         y_offs = 1;
     }
-    int left_occupied = is_highway_and_aqueduct(x - x_offs, y - y_offs, check_highway_routing);
-    int right_occupied = is_highway_and_aqueduct(x + x_offs, y + y_offs, check_highway_routing);
+    int left_occupied = is_highway_and_aqueduct(x - x_offs, y - y_offs, check_highway_routing, check_aqueduct_routing);
+    int right_occupied = is_highway_and_aqueduct(x + x_offs, y + y_offs, check_highway_routing, check_aqueduct_routing);
     if (left_occupied && right_occupied) {
         return 1;
     } else if (left_occupied && is_highway(x - x_offs * 2, y - y_offs * 2, check_highway_routing)) {
@@ -229,28 +233,28 @@ static int aqueduct_highway_line(int x, int y, int is_check_x, int check_highway
     return 0;
 }
 
-int map_can_place_aqueduct_on_highway(int grid_offset)
+int map_can_place_aqueduct_on_highway(int grid_offset, int check_aqueduct_routing)
 {
+    int x = map_grid_offset_to_x(grid_offset);
+    int y = map_grid_offset_to_y(grid_offset);
+
+    if (aqueduct_placement_creates_corner(x, y, x + 1, y, check_aqueduct_routing)) {
+        return 0;
+    } else if (aqueduct_placement_creates_corner(x, y, x - 1, y, check_aqueduct_routing)) {
+        return 0;
+    } else if (aqueduct_placement_creates_corner(x, y, x, y + 1, check_aqueduct_routing)) {
+        return 0;
+    } else if (aqueduct_placement_creates_corner(x, y, x, y - 1, check_aqueduct_routing)) {
+        return 0;
+    }
+
     if (!map_terrain_is(grid_offset, TERRAIN_HIGHWAY)) {
         return 1;
     }
 
-    int x = map_grid_offset_to_x(grid_offset);
-    int y = map_grid_offset_to_y(grid_offset);
-
-    if (aqueduct_placement_creates_corner(x, y, x + 1, y)) {
+    if (aqueduct_highway_line(x, y, 1, 0, check_aqueduct_routing)) {
         return 0;
-    } else if (aqueduct_placement_creates_corner(x, y, x - 1, y)) {
-        return 0;
-    } else if (aqueduct_placement_creates_corner(x, y, x, y + 1)) {
-        return 0;
-    } else if (aqueduct_placement_creates_corner(x, y, x, y - 1)) {
-        return 0;
-    }
-
-    if (aqueduct_highway_line(x, y, 1, 0)) {
-        return 0;
-    } else if (aqueduct_highway_line(x, y, 0, 0)) {
+    } else if (aqueduct_highway_line(x, y, 0, 0, check_aqueduct_routing)) {
         return 0;
     }
 
@@ -265,19 +269,19 @@ int map_can_place_highway_under_aqueduct(int grid_offset, int check_highway_rout
 
     int x = map_grid_offset_to_x(grid_offset);
     int y = map_grid_offset_to_y(grid_offset);
-    if (is_aqueduct(x - 1, y) && is_aqueduct(x, y - 1)) {
+    if (is_aqueduct(x - 1, y, 0) && is_aqueduct(x, y - 1, 0)) {
         return 0;
-    } else if (is_aqueduct(x, y - 1) && is_aqueduct(x + 1, y)) {
+    } else if (is_aqueduct(x, y - 1, 0) && is_aqueduct(x + 1, y, 0)) {
         return 0;
-    } else if (is_aqueduct(x + 1, y) && is_aqueduct(x, y + 1)) {
+    } else if (is_aqueduct(x + 1, y, 0) && is_aqueduct(x, y + 1, 0)) {
         return 0;
-    } else if (is_aqueduct(x, y + 1) && is_aqueduct(x - 1, y)) {
+    } else if (is_aqueduct(x, y + 1, 0) && is_aqueduct(x - 1, y, 0)) {
         return 0;
     }
 
-    if (aqueduct_highway_line(x, y, 1, check_highway_routing)) {
+    if (aqueduct_highway_line(x, y, 1, check_highway_routing, 0)) {
         return 0;
-    } else if (aqueduct_highway_line(x, y, 0, check_highway_routing)) {
+    } else if (aqueduct_highway_line(x, y, 0, check_highway_routing, 0)) {
         return 0;
     }
 

--- a/src/map/road_aqueduct.h
+++ b/src/map/road_aqueduct.h
@@ -9,7 +9,7 @@ int map_get_aqueduct_with_road_image(int grid_offset);
 
 int map_is_straight_road_for_aqueduct(int grid_offset);
 
-int map_can_place_aqueduct_on_highway(int grid_offset);
+int map_can_place_aqueduct_on_highway(int grid_offset, int check_aqueduct_routing);
 
 int map_can_place_highway_under_aqueduct(int grid_offset, int check_highway_routing);
 

--- a/src/map/routing.c
+++ b/src/map/routing.c
@@ -381,32 +381,7 @@ static int callback_calc_distance_build_road(int next_offset, int dist, int dire
 static int callback_calc_distance_build_aqueduct(int next_offset, int dist, int direction)
 {
     // check for existing highway/aqueduct tiles that won't work with this one
-    if (!map_can_place_aqueduct_on_highway(next_offset)) {
-        return 1;
-    }
-    if (map_terrain_is(next_offset, TERRAIN_HIGHWAY)) {
-        // only allow every other crossing to be enqueued so that aqueducts can't be built along highways
-        // don't check the first tile though because it might be on a highway
-        if (dist > 2) {
-            for (int i = 0; i < 4; i++) {
-                int surrounding_offset = next_offset + ROUTE_OFFSETS[i];
-                if (map_grid_is_valid_offset(surrounding_offset) && map_terrain_is(surrounding_offset, TERRAIN_HIGHWAY) && distance.determined.items[surrounding_offset]) {
-                    return 1;
-                }
-            }
-        }
-        // check up to two tiles ahead to see if we've cleared the highway. if we have, put in scores from here to there
-        int direction_offset = ROUTE_OFFSETS[direction];
-        for (int i = 1; i <= 2; i++) {
-            int next_offset2 = next_offset + direction_offset * i;
-            if (map_grid_is_valid_offset(next_offset2) && !map_terrain_is(next_offset2, TERRAIN_HIGHWAY)) {
-                for (int j = 0; j < i; j++) {
-                    distance.determined.items[next_offset + direction_offset * j] = dist + j;
-                }
-                enqueue(next_offset2, dist + i);
-                break;
-            }
-        }
+    if (!map_can_place_aqueduct_on_highway(next_offset, 1)) {
         return 1;
     }
 
@@ -437,7 +412,7 @@ static int callback_calc_distance_build_aqueduct(int next_offset, int dist, int 
 
 static int map_can_place_initial_road_or_aqueduct(int grid_offset, int is_aqueduct)
 {
-    if (is_aqueduct && !map_can_place_aqueduct_on_highway(grid_offset)) {
+    if (is_aqueduct && !map_can_place_aqueduct_on_highway(grid_offset, 0)) {
         return 0;
     }
     if (terrain_land_citizen.items[grid_offset] == CITIZEN_N1_BLOCKED) {

--- a/src/widget/city_building_ghost.c
+++ b/src/widget/city_building_ghost.c
@@ -654,7 +654,7 @@ static void draw_aqueduct(const map_tile *tile, int x, int y)
                     blocked = 1;
                 }
             } else if (map_terrain_is(grid_offset, TERRAIN_HIGHWAY)) {
-                blocked = !map_can_place_aqueduct_on_highway(grid_offset);
+                blocked = !map_can_place_aqueduct_on_highway(grid_offset, 0);
             } else if (map_terrain_is(grid_offset, TERRAIN_NOT_CLEAR)) {
                 blocked = 1;
             }


### PR DESCRIPTION
Just needed to modify the function to allow it to count routed tiles as aqueducts.

For posterity, the issue with the old function was that the first tile wasn't checked to see if it should be skipped. This was kind of a hack put in to allow for clicking and dragging across the highway if you started on the highway. Otherwise the aqueduct would think it needs to be skipped even though it can go across in a straight line using the first tile. See below image for what happens if the "dist" check is removed on the "skip" check.
![image](https://user-images.githubusercontent.com/2081059/220819364-0edcd6d3-6377-47b4-9350-fac6a61e1779.png)

Since the first checked tile was close enough to the end of the highway to clear it, it would get a score (as well as the next tile) and the tile after the highway ended would get enqueued.
![image](https://user-images.githubusercontent.com/2081059/220819653-b07772cc-bfac-4c5a-b95b-98a48da2037e.png)

This could be fixed by moving the "clear" check up into the "skip" check, but then it doesn't account for corners. Since map_can_place_aqueduct_on_highway() already handles all of these cases, I've changed the routing code to use it instead.