### PR TITLE
fix: Crash on events editor

### DIFF
--- a/res/manual/README_map_editor_scenario_events.md
+++ b/res/manual/README_map_editor_scenario_events.md
@@ -32,7 +32,7 @@ To import:
 + At the bottom there are two buttons, one for import and one for export.
 + Click the import button.
 + A file selection window will open.
-+ It will list all the files that are in your './events' folder. (A folder inside your Caesar 3 folder.)
++ It will list all the files that are in your './editor/events' folder. (A folder called 'editor' inside your Caesar 3 folder, and a folder called 'events' inside that.)
 + Select the file you want to import.
 + Now click proceed. (The tick box.)
 + The scenario events should update to reflect the events you just imported.

--- a/src/window/editor/scenario_event_details.c
+++ b/src/window/editor/scenario_event_details.c
@@ -277,7 +277,8 @@ static void set_amount_repeat_max(int value)
 
 static void button_click(int param1, int param2)
 {
-    if (param1 > MAX_VISIBLE_ROWS) {
+    if (param1 > MAX_VISIBLE_ROWS ||
+        param1 >= data.total_sub_items) {
         return;
     }
 

--- a/src/window/editor/scenario_events.c
+++ b/src/window/editor/scenario_events.c
@@ -141,7 +141,11 @@ static void draw_foreground(void)
 
 static void button_event(int button_index, int param2)
 {
-    window_editor_scenario_event_details_show(data.list[button_index - 1]->id);
+    int target_index = button_index - 1;
+    if (!data.list[target_index]) {
+        return;
+    }
+    window_editor_scenario_event_details_show(data.list[target_index]->id);
 }
 
 static void on_scroll(void)


### PR DESCRIPTION
fix: Crash on clicking on empty event area in editor.
fix: Crash on event details empty object.
fix: Readme incorrectly referring to ./events instead of ./editor/events