### PR TITLE
Make Depot cart pushers spread sickness

### DIFF
--- a/src/figure/service.c
+++ b/src/figure/service.c
@@ -560,6 +560,7 @@ int figure_service_provide_coverage(figure *f)
         case FIGURE_WAREHOUSEMAN:
         case FIGURE_DOCKER:
         case FIGURE_CART_PUSHER:
+        case FIGURE_DEPOT_CART_PUSHER:
             b = building_get(f->building_id);
             building *dest_b = building_get(f->destination_building_id);
 

--- a/src/widget/city_overlay_health.c
+++ b/src/widget/city_overlay_health.c
@@ -56,7 +56,7 @@ static int show_figure_sickness(const figure *f)
     return f->type == FIGURE_SURGEON || f->type == FIGURE_DOCTOR || f->type == FIGURE_DOCKER ||
            f->type == FIGURE_CART_PUSHER || f->type == FIGURE_TRADE_SHIP || f->type == FIGURE_WAREHOUSEMAN ||
            f->type == FIGURE_TRADE_CARAVAN || f->type == FIGURE_TRADE_CARAVAN_DONKEY || f->type == FIGURE_BARBER ||
-           f->type == FIGURE_BATHHOUSE_WORKER;
+           f->type == FIGURE_BATHHOUSE_WORKER || f->type == FIGURE_DEPOT_CART_PUSHER;
 }
 
 static int get_column_height_barber(const building *b)


### PR DESCRIPTION
- Depot cart pushers trigger sickness in houses they pass by, and spread sickness to granaries and warehouses, if they visited an infected building before.
- Show Depot cart pushers on sickness overlay

EDIT: tested, it works. ^^