### PR TITLE
fix: Crash for deleting custom event via UI

### DIFF
--- a/src/scenario/scenario_event.h
+++ b/src/scenario/scenario_event.h
@@ -15,7 +15,6 @@ scenario_action_t *scenario_event_get_action(scenario_event_t *event, int id);
 scenario_action_t *scenario_event_action_create(scenario_event_t *event, int type);
 void scenario_event_link_action(scenario_event_t *event, scenario_action_t *action);
 void scenario_event_initialize_new(scenario_event_t *event, int position);
-int scenario_event_is_valid(const scenario_event_t *event);
 
 
 int scenario_event_can_repeat(scenario_event_t *event);

--- a/src/scenario/scenario_event_data.h
+++ b/src/scenario/scenario_event_data.h
@@ -13,7 +13,8 @@ typedef enum {
     EVENT_STATE_UNDEFINED = 0,
     EVENT_STATE_DISABLED = 1,
     EVENT_STATE_ACTIVE = 2,
-    EVENT_STATE_PAUSED = 3
+    EVENT_STATE_PAUSED = 3,
+    EVENT_STATE_DELETED = 4
 } event_state;
 
 typedef enum {

--- a/src/scenario/scenario_events_controller.c
+++ b/src/scenario/scenario_events_controller.c
@@ -244,6 +244,13 @@ void scenario_events_load_state(buffer *buf_events, buffer *buf_conditions, buff
     info_load_state(buf_events);
     conditions_load_state(buf_conditions);
     actions_load_state(buf_actions);
+
+    scenario_event_t *current;
+    array_foreach(scenario_events, current) {
+        if (current->state == EVENT_STATE_DELETED) {
+            current->state = EVENT_STATE_UNDEFINED;
+        }
+    }
 }
 
 void scenario_events_process_all(void)


### PR DESCRIPTION
Fixed scenario file crashing on load when deleting custom event via UI, and event was in middle of the array.