### PR TITLE
Increased trader spawn rate

### DIFF
--- a/src/empire/city.c
+++ b/src/empire/city.c
@@ -445,9 +445,7 @@ void empire_city_generate_trader(void)
         } else {
             city_trade_add_land_trade_route();
         }
-        if (generate_trader(array_index, city)) {
-            break;
-        }
+        generate_trader(array_index, city);
     }
 }
 

--- a/src/figuretype/trader.c
+++ b/src/figuretype/trader.c
@@ -67,7 +67,7 @@ int figure_create_trade_caravan(int x, int y, int city_id)
     caravan->empire_city_id = city_id;
     caravan->action_state = FIGURE_ACTION_100_TRADE_CARAVAN_CREATED;
     random_generate_next();
-    caravan->wait_ticks = random_byte() % TRADER_INITIAL_WAIT;
+    caravan->wait_ticks = random_byte() & TRADER_INITIAL_WAIT;
     // donkey 1
     figure *donkey1 = figure_create(FIGURE_TRADE_CARAVAN_DONKEY, x, y, DIR_0_TOP);
     donkey1->action_state = FIGURE_ACTION_100_TRADE_CARAVAN_CREATED;
@@ -85,7 +85,7 @@ int figure_create_trade_ship(int x, int y, int city_id)
     ship->empire_city_id = city_id;
     ship->action_state = FIGURE_ACTION_110_TRADE_SHIP_CREATED;
     random_generate_next();
-    ship->wait_ticks = random_byte() % TRADER_INITIAL_WAIT;
+    ship->wait_ticks = random_byte() & TRADER_INITIAL_WAIT;
     return ship->id;
 }
 

--- a/src/figuretype/trader.c
+++ b/src/figuretype/trader.c
@@ -20,6 +20,7 @@
 #include "core/calc.h"
 #include "core/config.h"
 #include "core/image.h"
+#include "core/random.h"
 #include "empire/city.h"
 #include "empire/empire.h"
 #include "empire/object.h"
@@ -31,12 +32,14 @@
 #include "figure/route.h"
 #include "figure/trader.h"
 #include "figure/visited_buildings.h"
+#include "game/time.h"
 #include "map/routing.h"
 #include "map/routing_path.h"
 #include "scenario/map.h"
 #include "scenario/property.h"
 
 #define INFINITE 10000
+#define TRADER_INITIAL_WAIT GAME_TIME_TICKS_PER_DAY
 
 // Mercury Grand Temple base bonus to trader speed
 static int trader_bonus_speed(void)
@@ -63,7 +66,8 @@ int figure_create_trade_caravan(int x, int y, int city_id)
     figure *caravan = figure_create(FIGURE_TRADE_CARAVAN, x, y, DIR_0_TOP);
     caravan->empire_city_id = city_id;
     caravan->action_state = FIGURE_ACTION_100_TRADE_CARAVAN_CREATED;
-    caravan->wait_ticks = 10;
+    random_generate_next();
+    caravan->wait_ticks = random_byte() % TRADER_INITIAL_WAIT;
     // donkey 1
     figure *donkey1 = figure_create(FIGURE_TRADE_CARAVAN_DONKEY, x, y, DIR_0_TOP);
     donkey1->action_state = FIGURE_ACTION_100_TRADE_CARAVAN_CREATED;
@@ -80,7 +84,8 @@ int figure_create_trade_ship(int x, int y, int city_id)
     figure *ship = figure_create(FIGURE_TRADE_SHIP, x, y, DIR_0_TOP);
     ship->empire_city_id = city_id;
     ship->action_state = FIGURE_ACTION_110_TRADE_SHIP_CREATED;
-    ship->wait_ticks = 10;
+    random_generate_next();
+    ship->wait_ticks = random_byte() % TRADER_INITIAL_WAIT;
     return ship->id;
 }
 
@@ -479,7 +484,7 @@ void figure_trade_caravan_action(figure *f)
         case FIGURE_ACTION_100_TRADE_CARAVAN_CREATED:
             f->is_ghost = 1;
             f->wait_ticks++;
-            if (f->wait_ticks > 20) {
+            if (f->wait_ticks > TRADER_INITIAL_WAIT) {
                 f->wait_ticks = 0;
                 go_to_next_storage(f);
             }
@@ -770,7 +775,7 @@ void figure_trade_ship_action(figure *f)
             f->trader_amount_bought = 0;
             f->is_ghost = 1;
             f->wait_ticks++;
-            if (f->wait_ticks > 20) {
+            if (f->wait_ticks > TRADER_INITIAL_WAIT) {
                 f->wait_ticks = 0;
                 map_point queue_tile;
                 int dock_id = building_dock_get_destination(f->id, 0, &queue_tile);

--- a/src/game/tick.c
+++ b/src/game/tick.c
@@ -153,7 +153,6 @@ static void advance_tick(void)
         case 7: map_road_network_update(); break;
         case 8: building_granaries_calculate_stocks(); break;
         case 9: city_buildings_update_plague(); break;
-        case 10: empire_city_generate_trader(); break;
         case 12: house_service_decay_houses_covered(); break;
         case 16: city_resource_calculate_warehouse_stocks(); break;
         case 17: city_resource_calculate_food_stocks_and_supply_wheat(); break;

--- a/src/game/tick.c
+++ b/src/game/tick.c
@@ -153,6 +153,7 @@ static void advance_tick(void)
         case 7: map_road_network_update(); break;
         case 8: building_granaries_calculate_stocks(); break;
         case 9: city_buildings_update_plague(); break;
+        case 10: empire_city_generate_trader(); break;
         case 12: house_service_decay_houses_covered(); break;
         case 16: city_resource_calculate_warehouse_stocks(); break;
         case 17: city_resource_calculate_food_stocks_and_supply_wheat(); break;


### PR DESCRIPTION
This makes traders spawn more like immigrants, allowing for significantly more trade caravan throughput on maps with a large number of trade cities. Previously, we were limited to 192 trade caravans a year based on the following:

only 1 city could spawn a trade caravan per day.
16 days in 1 month.
12 months in 1 year.
12 months * 16 days * 1 spawn = 192 potential caravan spawns per year that have to be shared by all trade cities.

However certain zardoz were making maps with 14 trade cities, which would get throughput limited by the following:
12 months per year / 2 months time for the caravan to pass through the city * 3 caravans allowed per trade city  = 18 caravans per year
18 caravans per year * 14 trade cities = 252 caravan spawns required to maximize trade throughput

Getting trade caravans through the city faster would just make things worse, as the player would need 504 spawn chances if they got the caravans through in 1 month instead of 2.

The new logic allows for every city to spawn a trader every day (unless that city spawned a trade caravan in the past 4 days or a trade ship in the last 30 days, but that logic isn't new). The traders wait_ticks are randomly offset by 50 (the number of ticks in a day) and traders now hold in their CREATED state until the wait ticks passes 50 instead of the previous value of 20. This means for the scenario above, we can get:
16 days per month / 4 days per city caravan spawn = 4 potential caravan spawns per month per city
4 caravans per month per city * 12 months per year = 48 caravans per year per city
48 caravans per year per city * 14 trade cities = 672 potential trade spawns

The nice thing about this new approach is it scales with the number of trade cities so map makers can go crazy!