### PR TITLE
fix: XML export of repeating events

### DIFF
--- a/src/scenario/scenario_events_export_xml.c
+++ b/src/scenario/scenario_events_export_xml.c
@@ -224,10 +224,10 @@ static int export_event(scenario_event_t *event)
         xml_exporter_add_attribute_int("repeat_months_min", event->repeat_months_min);
     }
     if (event->repeat_months_max > 0) {
-        xml_exporter_add_attribute_int("repeat_months_max", event->repeat_months_min);
+        xml_exporter_add_attribute_int("repeat_months_max", event->repeat_months_max);
     }
     if (event->max_number_of_repeats > 0) {
-        xml_exporter_add_attribute_int("max_number_of_repeats", event->repeat_months_min);
+        xml_exporter_add_attribute_int("max_number_of_repeats", event->max_number_of_repeats);
     }
 
     xml_exporter_new_element("conditions", 1);


### PR DESCRIPTION
Fix the max and repeating count of events incorrectly exporting the value of the min.