### PR TITLE
Fix line too long in Options

### DIFF
--- a/src/translation/english.c
+++ b/src/translation/english.c
@@ -100,7 +100,7 @@ static translation_string all_strings[] = {
     {TR_CONFIG_DELIVER_ONLY_TO_ACCEPTING_GRANARIES, "Food isn't delivered to getting granaries"},
     {TR_CONFIG_ALL_HOUSES_MERGE, "All houses merge"},
     {TR_CONFIG_WINE_COUNTS_IF_OPEN_TRADE_ROUTE, "Open trade route counts as providing different wine type"},
-    {TR_CONFIG_RANDOM_COLLAPSES_TAKE_MONEY, "Randomly collapsing clay pits and iron mines take some money instead"},
+    {TR_CONFIG_RANDOM_COLLAPSES_TAKE_MONEY, "Randomly collapsing pits and mines take some money instead"},
     {TR_CONFIG_MULTIPLE_BARRACKS, "Allow building multiple barracks" },
     {TR_CONFIG_NOT_ACCEPTING_WAREHOUSES, "Warehouses and granaries don't accept anything when built"},
     {TR_CONFIG_HOUSES_DONT_EXPAND_INTO_GARDENS, "Houses don't expand into gardens"},


### PR DESCRIPTION
`Randomly collapsing clay pits and iron mines take some money instead` in Options - City Management is a bit too long and cut.

![collapse](https://github.com/Keriew/augustus/assets/11946570/10d39fee-c9a2-4641-bd6f-adde515b6f8c)

Remove `clay` and `iron` to shorten it.
There's also sand pits and gold mines now anyway (which I think can randomly collapse too, not sure).

EDIT: well, they can't randomly collapse (they should imo, for consistency).

EDIT2: linked to discussion https://github.com/Keriew/augustus/discussions/990 now.
