### PR TITLE
Display Caravanserai and Supply Post on Food Stocks overlay

### DIFF
--- a/src/widget/city_overlay_other.c
+++ b/src/widget/city_overlay_other.c
@@ -47,7 +47,8 @@ static int show_building_religion(const building *b)
 
 static int show_building_food_stocks(const building *b)
 {
-    return b->type == BUILDING_MARKET || b->type == BUILDING_WHARF || b->type == BUILDING_GRANARY;
+    return b->type == BUILDING_MARKET || b->type == BUILDING_WHARF || b->type == BUILDING_GRANARY ||
+           b->type == BUILDING_CARAVANSERAI || b->type == BUILDING_MESS_HALL;
 }
 
 static int show_building_tax_income(const building *b)
@@ -135,6 +136,8 @@ static int show_figure_efficiency(const figure *f)
 static int show_figure_food_stocks(const figure *f)
 {
     if (f->type == FIGURE_MARKET_SUPPLIER || f->type == FIGURE_MARKET_TRADER ||
+        f->type == FIGURE_CARAVANSERAI_SUPPLIER || f->type == FIGURE_CARAVANSERAI_COLLECTOR ||
+        f->type == FIGURE_MESS_HALL_SUPPLIER || f->type == FIGURE_MESS_HALL_FORT_SUPPLIER || f->type == FIGURE_MESS_HALL_COLLECTOR ||
         f->type == FIGURE_DELIVERY_BOY || f->type == FIGURE_FISHING_BOAT) {
         return 1;
     } else if (f->type == FIGURE_CART_PUSHER) {

--- a/src/window/city.c
+++ b/src/window/city.c
@@ -439,6 +439,8 @@ static void show_overlay_from_grid_offset(int grid_offset)
             break;
         case BUILDING_MARKET:
         case BUILDING_GRANARY:
+        case BUILDING_CARAVANSERAI:
+        case BUILDING_MESS_HALL:
         case BUILDING_FRUIT_FARM:
         case BUILDING_OLIVE_FARM:
         case BUILDING_PIG_FARM:


### PR DESCRIPTION
Make easier to spot them in dense cities and to follow their walkers.