### PR TITLE
Show only infected cart pushers on Sickness overlay

### DIFF
--- a/src/widget/city_overlay_health.c
+++ b/src/widget/city_overlay_health.c
@@ -53,10 +53,20 @@ static int show_figure_hospital(const figure *f)
 
 static int show_figure_sickness(const figure *f)
 {
-    return f->type == FIGURE_SURGEON || f->type == FIGURE_DOCTOR || f->type == FIGURE_DOCKER ||
-           f->type == FIGURE_CART_PUSHER || f->type == FIGURE_TRADE_SHIP || f->type == FIGURE_WAREHOUSEMAN ||
-           f->type == FIGURE_TRADE_CARAVAN || f->type == FIGURE_TRADE_CARAVAN_DONKEY || f->type == FIGURE_BARBER ||
-           f->type == FIGURE_BATHHOUSE_WORKER || f->type == FIGURE_DEPOT_CART_PUSHER;
+    if (f->type == FIGURE_SURGEON || f->type == FIGURE_DOCTOR ||
+        f->type == FIGURE_TRADE_SHIP || f->type == FIGURE_TRADE_CARAVAN ||
+        f->type == FIGURE_TRADE_CARAVAN_DONKEY || f->type == FIGURE_BARBER ||
+        f->type == FIGURE_BATHHOUSE_WORKER) {
+        return 1;
+    } else if (f->type == FIGURE_DOCKER || f->type == FIGURE_CART_PUSHER ||
+               f->type == FIGURE_WAREHOUSEMAN || f->type == FIGURE_DEPOT_CART_PUSHER) {
+               building *b = building_get(f->building_id);
+               building *dest_b = building_get(f->destination_building_id);
+               if (b->sickness_level > 0 || dest_b->sickness_level > 0) {
+               return 1;
+               }
+    }
+    return 0;
 }
 
 static int get_column_height_barber(const building *b)


### PR DESCRIPTION
Shows cart pushers on sickness overlay only if they originate from a building having sickness or go to a building having sickness.

Tested. Works correctly.
Well, cart pushers pops in or out on the overlay if sickness increases >0 or decreases to 0 during their trips, but I think it's ok, let's say they are cured by the fresh air of the city ^^