### PR TITLE
Bug/Don't allow attack ghost targets

### DIFF
--- a/src/figure/combat.c
+++ b/src/figure/combat.c
@@ -175,7 +175,8 @@ int figure_combat_get_target_for_soldier(int x, int y, int max_distance)
     int min_distance = 10000;
     for (int i = 1; i < figure_count(); i++) {
         figure *f = figure_get(i);
-        if (figure_is_dead(f)) {
+        if (figure_is_dead(f) || f->is_ghost ) {
+            // Do not allow to target dead and enemies located outside of the map
             continue;
         }
         if (figure_is_enemy(f) || f->type == FIGURE_RIOTER || is_attacking_native(f)) {
@@ -317,7 +318,8 @@ int figure_combat_get_missile_target_for_soldier(figure *shooter, int max_distan
     formation *l = formation_get(shooter->formation_id);
     for (int i = 1; i < figure_count(); i++) {
         figure *f = figure_get(i);
-        if (figure_is_dead(f)) {
+        if (figure_is_dead(f) || f->is_ghost ) {
+            // Do not allow to target dead and enemies located outside of the map
             continue;
         }
         if (is_valid_missile_target(f, l)) {
@@ -338,6 +340,10 @@ int figure_combat_get_missile_target_for_soldier(figure *shooter, int max_distan
 int figure_combat_get_missile_target_for_enemy(figure *enemy, int max_distance, int attack_citizens,
                                                map_point *tile)
 {
+    if (enemy->is_ghost) {
+        // Do not allow enemies to attack from outside of the map
+        return 0;
+    }
     int x = enemy->x;
     int y = enemy->y;
 
@@ -421,7 +427,8 @@ void figure_combat_attack_figure_at(figure *f, int grid_offset)
             break;
         }
         figure *opponent = figure_get(opponent_id);
-        if (opponent_id == f->id) {
+        if (opponent_id == f->id || opponent->is_ghost) {
+            // Do not allow troops to attack themselves or enemies located outside of the map
             opponent_id = opponent->next_figure_id_on_same_tile;
             continue;
         }

--- a/src/scenario/invasion.c
+++ b/src/scenario/invasion.c
@@ -261,10 +261,14 @@ static int start_invasion(int enemy_type, int amount, int invasion_point, format
         x = entry_point.x;
         y = entry_point.y;
     } else {
-        int num_points = 0;
-        for (int i = 0; i < MAX_INVASION_POINTS; i++) {
-            if (scenario.invasion_points[i].x != -1) {
-                num_points++;
+        // Determinate maximum number of valid invasion points.
+        // Strip out invalid invasion points from the end of the list.
+        int num_points = MAX_INVASION_POINTS;
+        for (int i = MAX_INVASION_POINTS - 1; i >= 0; i--) {
+            if (scenario.invasion_points[i].x == -1) {
+                num_points--;
+            } else if (num_points != MAX_INVASION_POINTS) {
+                break;
             }
         }
         if (invasion_point == MAX_INVASION_POINTS) { // random
@@ -336,6 +340,7 @@ static int start_invasion(int enemy_type, int amount, int invasion_point, format
                 f->faction_id = 0;
                 f->is_friendly = 0;
                 f->action_state = FIGURE_ACTION_151_ENEMY_INITIAL;
+                // TODO: should we adjust wait ticks to make enemy camping harder?
                 f->wait_ticks = 200 * seq + 10 * fig + 10;
                 f->formation_id = formation_id;
                 f->name = figure_name_get(type, enemy_type);


### PR DESCRIPTION
# Description

This fix disallows attacking enemy troops till they appear on map. And also disallows enemy troops to attack from outside of the map. Same restriction applies to tower ballistas & sentries.

Additionally invasion points random generation has been fixed (in some custom maps it was impossible to invade from some invasion points)