### PR TITLE
Advisor: hold festival. Text alignment

### DIFF
--- a/src/window/advisor/trade.c
+++ b/src/window/advisor/trade.c
@@ -240,12 +240,12 @@ static void draw_resource_info(const grid_box_item *item)
         if (resource_is_food(resource)) {
             amount += city_resource_count_food_on_granaries(resource) / 100;
         }
-        text_draw_number_centered(amount, item->x + 140, item->y + 15, 60, FONT_NORMAL_WHITE);
+        text_draw_number_centered(amount, item->x + 130, item->y + 15, 60, FONT_NORMAL_WHITE);
     } else {
-        lang_text_draw_centered(56, 2, item->x + 140, item->y + 15, 60, FONT_NORMAL_WHITE);
+        lang_text_draw_centered(56, 2, item->x + 130, item->y + 15, 60, FONT_NORMAL_WHITE);
     }
     if (city_resource_is_mothballed(resource)) {
-        lang_text_draw_centered(18, 5, item->x + 180, item->y + 15, 100, FONT_NORMAL_WHITE);
+        lang_text_draw_centered(18, 5, item->x + 160, item->y + 15, 100, FONT_NORMAL_WHITE);
     }
     draw_resource_status_text(resource, item->x + 176, item->y + 5, item->width - 206);
 

--- a/src/window/hold_festival.c
+++ b/src/window/hold_festival.c
@@ -33,14 +33,14 @@ static image_button image_buttons_bottom[] = {
 };
 
 static generic_button buttons_gods_size[] = {
-    {70, 96, 80, 90, button_god},
-    {170, 96, 80, 90, button_god, 0, 1},
-    {270, 96, 80, 90, button_god, 0, 2},
-    {370, 96, 80, 90, button_god, 0, 3},
-    {470, 96, 80, 90, button_god, 0, 4},
-    {102, 216, 430, 26, button_size, 0, 1},
-    {102, 246, 430, 26, button_size, 0, 2},
-    {102, 276, 430, 26, button_size, 0, 3},
+    {80, 96, 80, 90, button_god},
+    {180, 96, 80, 90, button_god, 0, 1},
+    {280, 96, 80, 90, button_god, 0, 2},
+    {380, 96, 80, 90, button_god, 0, 3},
+    {480, 96, 80, 90, button_god, 0, 4},
+    {82, 216, 477, 26, button_size, 0, 1},
+    {82, 246, 477, 26, button_size, 0, 2},
+    {82, 276, 477, 26, button_size, 0, 3},
 };
 
 static unsigned int focus_button_id;
@@ -63,27 +63,27 @@ static void draw_buttons(void)
         wine_image_id = resource_get_data(RESOURCE_WINE)->image.icon;
     }
     // small festival
-    button_border_draw(102, 216, 430, 26, color == COLOR_MASK_NONE && focus_button_id == 6);
-    int width = lang_text_draw_colored(58, 31, 110, 224, font, color);
-    lang_text_draw_amount_colored(8, 0, city_festival_small_cost(), 110 + width, 224, font, color);
+    button_border_draw(82, 216, 477, 26, color == COLOR_MASK_NONE && focus_button_id == 6);
+    int width = lang_text_draw_colored(58, 31, 92, 224, font, color);
+    lang_text_draw_amount_colored(8, 0, city_festival_small_cost(), 92 + width, 224, font, color);
 
     // large festival
-    button_border_draw(102, 246, 430, 26, color == COLOR_MASK_NONE && focus_button_id == 7);
-    width = lang_text_draw_colored(58, 32, 110, 254, font, color);
-    lang_text_draw_amount_colored(8, 0, city_festival_large_cost(), 110 + width, 254, font, color);
+    button_border_draw(82, 246, 477, 26, color == COLOR_MASK_NONE && focus_button_id == 7);
+    width = lang_text_draw_colored(58, 32, 92, 254, font, color);
+    lang_text_draw_amount_colored(8, 0, city_festival_large_cost(), 92 + width, 254, font, color);
 
     if (city_festival_out_of_wine() && !city_finance_out_of_money()) {
         font = FONT_NORMAL_PLAIN;
         color = COLOR_FONT_LIGHT_GRAY;
-        wine_image_id = assets_get_image_id("UI", "Grand Festival Wine Disabled");        
+        wine_image_id = assets_get_image_id("UI", "Grand Festival Wine Disabled");
     }
 
     // grand festival
-    button_border_draw(102, 276, 430, 26, color == COLOR_MASK_NONE && focus_button_id == 8);
-    width = lang_text_draw_colored(58, 33, 110, 284, font, color);
-    width += lang_text_draw_amount_colored(8, 0, city_festival_grand_cost(), 110 + width, 284, font, color);
-    width += lang_text_draw_amount_colored(8, 10, city_festival_grand_wine(), 120 + width, 284, font, color);
-    image_draw(wine_image_id, 120 + width, 279, COLOR_MASK_NONE, SCALE_NONE);
+    button_border_draw(82, 276, 477, 26, color == COLOR_MASK_NONE && focus_button_id == 8);
+    width = lang_text_draw_colored(58, 33, 92, 284, font, color);
+    width += lang_text_draw_amount_colored(8, 0, city_festival_grand_cost(), 92 + width, 284, font, color);
+    width += lang_text_draw_amount_colored(8, 10, city_festival_grand_wine(), 97 + width, 284, font, color);
+    image_draw(wine_image_id, 97 + width, 279, COLOR_MASK_NONE, SCALE_NONE);
 }
 
 static void draw_background(void)
@@ -96,10 +96,10 @@ static void draw_background(void)
     lang_text_draw_centered(58, 25 + city_festival_selected_god(), 48, 60, 544, FONT_LARGE_BLACK);
     for (int god = 0; god < MAX_GODS; god++) {
         if (god == city_festival_selected_god()) {
-            button_border_draw(100 * god + 66, 92, 90, 100, 1);
-            image_draw(image_group(GROUP_PANEL_WINDOWS) + god + 21, 100 * god + 70, 96, COLOR_MASK_NONE, SCALE_NONE);
+            button_border_draw(100 * god + 75, 91, 91, 101, 1);
+            image_draw(image_group(GROUP_PANEL_WINDOWS) + god + 21, 100 * god + 80, 96, COLOR_MASK_NONE, SCALE_NONE);
         } else {
-            image_draw(image_group(GROUP_PANEL_WINDOWS) + god + 16, 100 * god + 70, 96, COLOR_MASK_NONE, SCALE_NONE);
+            image_draw(image_group(GROUP_PANEL_WINDOWS) + god + 16, 100 * god + 80, 96, COLOR_MASK_NONE, SCALE_NONE);
         }
     }
     draw_buttons();
@@ -122,10 +122,10 @@ static void draw_foreground(void)
 {
     graphics_in_dialog();
     if (!city_finance_out_of_money()) {
-        button_border_draw(102, 216, 430, 26, focus_button_id == 6);
-        button_border_draw(102, 246, 430, 26, focus_button_id == 7);
+        button_border_draw(82, 216, 477, 26, focus_button_id == 6);
+        button_border_draw(82, 246, 477, 26, focus_button_id == 7);
         if (!city_festival_out_of_wine()) {
-            button_border_draw(102, 276, 430, 26, focus_button_id == 8);
+            button_border_draw(82, 276, 477, 26, focus_button_id == 8);
         }
     }
     image_buttons_draw(0, 0, image_buttons_bottom, active_image_buttons());

--- a/src/window/set_salary.c
+++ b/src/window/set_salary.c
@@ -58,8 +58,8 @@ static void draw_foreground(void)
     int dialog_width = get_dialog_width();
     int dialog_x = 128 - (dialog_width - MIN_DIALOG_WIDTH) / 2;
     outer_panel_draw(dialog_x, 32, dialog_width / BLOCK_SIZE, 25);
-    image_draw(resource_get_data(RESOURCE_DENARII)->image.icon, dialog_x + 16, 48, COLOR_MASK_NONE, SCALE_NONE);
-    lang_text_draw_centered(52, 15, dialog_x + 48, 48, dialog_width - 64, FONT_LARGE_BLACK);
+    image_draw(resource_get_data(RESOURCE_DENARII)->image.icon, dialog_x + 10, 42, COLOR_MASK_NONE, SCALE_NONE);
+    lang_text_draw_centered(52, 15, dialog_x + 25, 48, dialog_width - 64, FONT_LARGE_BLACK);
 
     inner_panel_draw(144, 80, 22, 15);
 
@@ -76,7 +76,7 @@ static void draw_foreground(void)
             lang_text_draw_multiline(52, 71, 152, 336, 336, FONT_NORMAL_BLACK);
         }
     } else {
-        lang_text_draw_multiline(52, 77, 152, 336, 336, FONT_NORMAL_BLACK);
+        lang_text_draw_multiline(52, 77, 150, 336, 340, FONT_NORMAL_BLACK);
     }
     button_border_draw(240, 395, 160, 20, focus_button_id == 1);
     lang_text_draw_centered(13, 4, 176, 400, 288, FONT_NORMAL_BLACK);


### PR DESCRIPTION
- Centering the frame around the images of the gods
- Preventing text from going beyond the button in the rus locale.

before
![2025-02-17_195725](https://github.com/user-attachments/assets/d4b4d219-a1de-4dd4-aeca-7fcbd0857db7)
after
![2025-02-17_195853](https://github.com/user-attachments/assets/c5cc1a88-dc06-475c-a415-bce242f909f3)

trade advisor: shift the text 'OFF' to the left
before
![2025-02-17_215459](https://github.com/user-attachments/assets/467f27a4-98b3-4071-8d3d-b2a287a49c33)
after
![2025-02-17_215141](https://github.com/user-attachments/assets/bafaa4ce-be35-46d3-8458-303ee642e2b1)

offset in window "set salary level"
before
![2025-03-11_175233](https://github.com/user-attachments/assets/f6fc3601-598e-4078-9a7d-3fca59e5fd2c)
after
![2025-03-11_182128](https://github.com/user-attachments/assets/a9789610-ee39-40ea-a13c-89afee65b877)
