### PR TITLE
overlay 'crime': show all armed citizens. overlay 'enemy': show all a…

### DIFF
--- a/src/widget/city_overlay_risks.c
+++ b/src/widget/city_overlay_risks.c
@@ -106,8 +106,7 @@ static int show_building_enemy(const building *b)
     return b->type == BUILDING_PREFECTURE
         || b->type == BUILDING_WATCHTOWER || b->type == BUILDING_TOWER
         || b->type == BUILDING_FORT || b->type == BUILDING_FORT_GROUND
-        || b->type == BUILDING_GATEHOUSE || b->type == BUILDING_PALISADE_GATE || b->type == BUILDING_PALISADE
-        || b->type == BUILDING_WALL; // The wall is not displayed! Why?
+        || b->type == BUILDING_GATEHOUSE || b->type == BUILDING_PALISADE_GATE || b->type == BUILDING_PALISADE;
 }
 
 static int show_figure_fire(const figure *f)
@@ -472,7 +471,6 @@ const city_overlay *city_overlay_for_enemy(void)
     static city_overlay overlay = {
         OVERLAY_ENEMY,
         COLUMN_COLOR_RED,
-        //show_building_none,
         show_building_enemy,
         show_figure_enemy,
         get_column_height_none,

--- a/src/widget/city_overlay_risks.c
+++ b/src/widget/city_overlay_risks.c
@@ -101,6 +101,15 @@ static int show_building_none(const building *b)
     return 0;
 }
 
+static int show_building_enemy(const building *b)
+{
+    return b->type == BUILDING_PREFECTURE
+        || b->type == BUILDING_WATCHTOWER || b->type == BUILDING_TOWER
+        || b->type == BUILDING_FORT || b->type == BUILDING_FORT_GROUND
+        || b->type == BUILDING_GATEHOUSE || b->type == BUILDING_PALISADE_GATE || b->type == BUILDING_PALISADE
+        || b->type == BUILDING_WALL; // The wall is not displayed! Why?
+}
+
 static int show_figure_fire(const figure *f)
 {
     return f->type == FIGURE_PREFECT;
@@ -113,9 +122,9 @@ static int show_figure_damage(const figure *f)
 
 static int show_figure_crime(const figure *f)
 {
-    return f->type == FIGURE_PREFECT ||
-        f->type == FIGURE_CRIMINAL || f->type == FIGURE_RIOTER || f->type == FIGURE_PROTESTER
-        || f->type == FIGURE_CRIMINAL_LOOTER || f->type == FIGURE_CRIMINAL_ROBBER;
+    const figure_properties *props = figure_properties_for_type(f->type);
+    return props->category == FIGURE_CATEGORY_ARMED || props->category == FIGURE_CATEGORY_CRIMINAL
+        || f->type == FIGURE_ARROW || f->type == FIGURE_JAVELIN || f->type == FIGURE_BOLT;
 }
 
 static int show_figure_problems(const figure *f)
@@ -139,7 +148,12 @@ static int show_figure_native(const figure *f)
 static int show_figure_enemy(const figure *f)
 {
     const figure_properties *props = figure_properties_for_type(f->type);
-    return props->category == FIGURE_CATEGORY_HOSTILE || props->category == FIGURE_CATEGORY_NATIVE || props->category == FIGURE_CATEGORY_AGGRESSIVE_ANIMAL;
+    return props->category == FIGURE_CATEGORY_HOSTILE || props->category == FIGURE_CATEGORY_NATIVE
+        || props->category == FIGURE_CATEGORY_AGGRESSIVE_ANIMAL
+        || props->category == FIGURE_CATEGORY_ARMED
+        || f->type == FIGURE_BALLISTA
+        || f->type == FIGURE_ARROW || f->type == FIGURE_JAVELIN || f->type == FIGURE_BOLT
+        || f->type == FIGURE_CATAPULT_MISSILE;
 }
 
 static int get_column_height_fire(const building *b)
@@ -458,7 +472,8 @@ const city_overlay *city_overlay_for_enemy(void)
     static city_overlay overlay = {
         OVERLAY_ENEMY,
         COLUMN_COLOR_RED,
-        show_building_none,
+        //show_building_none,
+        show_building_enemy,
         show_figure_enemy,
         get_column_height_none,
         0,


### PR DESCRIPTION
- overlay 'crime': show all armed citizens.
- overlay 'enemy': show all armed citizens and military buildings.
- additionally, projectiles for these layers is displayed.

crime layer
![2025-02-18_123226](https://github.com/user-attachments/assets/f54fd702-70d0-410e-9638-f1020e30a062)

enemy layer
![2025-02-17_203953](https://github.com/user-attachments/assets/7bd27344-f3f3-4970-a4ce-f752b196d852)

