### PR TITLE
Increasing the desirability radius

### DIFF
--- a/src/building/house_evolution.c
+++ b/src/building/house_evolution.c
@@ -65,7 +65,7 @@ static int has_required_goods_and_services(building *house, int for_upgrade, int
     int water = model->water;
     if (!house->has_water_access) {
         if (water >= 2) {
-            if (level > HOUSE_SMALL_CASA) {                
+            if (level > HOUSE_SMALL_CASA) {
                 ++demands->missing.fountain;
                 return  0;
             } else if (!house->has_well_access) {
@@ -624,7 +624,7 @@ void building_house_determine_evolve_text(building *house, int worst_desirabilit
 
     if (water == 2 && !house->has_water_access) {
         if (!house->has_latrines_access) {
-            house->data.house.evolve_text_id = 67;        
+            house->data.house.evolve_text_id = 67;
             return;
         } else if (level >= HOUSE_LARGE_CASA) {
             house->data.house.evolve_text_id = 2;
@@ -777,9 +777,9 @@ void building_house_determine_evolve_text(building *house, int worst_desirabilit
             house->data.house.evolve_text_id = 31;
             return;
         } else if (!house->has_latrines_access) {
-            house->data.house.evolve_text_id = 68;        
+            house->data.house.evolve_text_id = 68;
             return;
-        }        
+        }
     }
 
     if (water == 2 && !house->has_water_access) {
@@ -789,7 +789,7 @@ void building_house_determine_evolve_text(building *house, int worst_desirabilit
         }
     }
 
-    
+
     // entertainment
     entertainment = model->entertainment;
     if (house->data.house.entertainment < entertainment) {
@@ -939,7 +939,7 @@ building_type building_house_determine_worst_desirability_building_type(const bu
     int lowest_desirability = 0;
     building_type lowest_building_type = BUILDING_NONE;
     int x_min, y_min, x_max, y_max;
-    map_grid_get_area(house->x, house->y, 1, 6, &x_min, &y_min, &x_max, &y_max);
+    map_grid_get_area(house->x, house->y, 1, 8, &x_min, &y_min, &x_max, &y_max);
 
     for (int y = y_min; y <= y_max; y++) {
         for (int x = x_min; x <= x_max; x++) {

--- a/src/building/model.c
+++ b/src/building/model.c
@@ -195,12 +195,12 @@ int model_load(void)
 const model_building MODEL_ROADBLOCK = { 12,0,0,0,0 };
 const model_building MODEL_WORK_CAMP = { 150,-10,2,3,4,20 };
 const model_building MODEL_ARCHITECT_GUILD = { 200,-8,1,2,4,12 };
-const model_building MODEL_GRAND_TEMPLE_CERES = { 2500,20,2,-4,5,50 };
-const model_building MODEL_GRAND_TEMPLE_NEPTUNE = { 2500,20,2,-4,5,50 };
-const model_building MODEL_GRAND_TEMPLE_MERCURY = { 2500,20,2,-4,5,50 };
-const model_building MODEL_GRAND_TEMPLE_MARS = { 2500,20,2,-4,5,50 };
-const model_building MODEL_GRAND_TEMPLE_VENUS = { 2500,20,2,-4,5,50 };
-const model_building MODEL_PANTHEON = { 3500,20,2,-4,5,50 };
+const model_building MODEL_GRAND_TEMPLE_CERES = { 2500,20,2,-4,8,50 };
+const model_building MODEL_GRAND_TEMPLE_NEPTUNE = { 2500,20,2,-4,8,50 };
+const model_building MODEL_GRAND_TEMPLE_MERCURY = { 2500,20,2,-4,8,50 };
+const model_building MODEL_GRAND_TEMPLE_MARS = { 2500,20,2,-4,8,50 };
+const model_building MODEL_GRAND_TEMPLE_VENUS = { 2500,20,2,-4,8,50 };
+const model_building MODEL_PANTHEON = { 3500,20,2,-4,8,50 };
 const model_building MODEL_LIGHTHOUSE = { 1000,6,1,-1,4,20 };
 const model_building MODEL_MESS_HALL = { 100,-8,1,2,4,10 };
 const model_building MODEL_TAVERN = { 40,-2,1,1,6,8 };
@@ -306,7 +306,7 @@ const model_building *model_get_building(building_type type)
         case BUILDING_OVERGROWN_GARDENS:
             return &buildings[BUILDING_GARDENS];
         case BUILDING_ARMOURY:
-            return &MODEL_ARMOURY;  
+            return &MODEL_ARMOURY;
         case BUILDING_LATRINES:
             return &MODEL_LATRINE;
         default:
@@ -316,7 +316,7 @@ const model_building *model_get_building(building_type type)
     if ((type >= BUILDING_PINE_TREE && type <= BUILDING_SENATOR_STATUE) ||
         type == BUILDING_HEDGE_DARK || type == BUILDING_HEDGE_LIGHT ||
         type == BUILDING_DECORATIVE_COLUMN || type == BUILDING_LOOPED_GARDEN_WALL ||
-        type == BUILDING_COLONNADE || type == BUILDING_LOOPED_GARDEN_WALL || 
+        type == BUILDING_COLONNADE || type == BUILDING_LOOPED_GARDEN_WALL ||
         type == BUILDING_ROOFED_GARDEN_WALL || type == BUILDING_GARDEN_PATH ||
         type == BUILDING_PANELLED_GARDEN_WALL || type == BUILDING_GLADIATOR_STATUE) {
         return &buildings[BUILDING_SMALL_STATUE];

--- a/src/map/desirability.c
+++ b/src/map/desirability.c
@@ -50,8 +50,8 @@ static void add_desirability_at_distance(int x, int y, int size, int distance, i
 static void add_to_terrain(int x, int y, int size, int desirability, int step, int step_size, int range)
 {
     if (size > 0) {
-        if (range > 6) {
-            range = 6;
+        if (range > 8) {
+            range = 8;
         }
         int tiles_within_step = 0;
         int distance = 1;

--- a/src/map/ring.c
+++ b/src/map/ring.c
@@ -4,8 +4,8 @@
 #include "map/grid.h"
 
 static struct {
-    ring_tile tiles[1700];
-    int index[8][7];
+    ring_tile tiles[3000];
+    int index[8][9];
 } data;
 
 void map_ring_init(void)
@@ -13,7 +13,7 @@ void map_ring_init(void)
     int index = 0;
     int x, y;
     for (int size = 1; size <= 7; size++) {
-        for (int dist = 1; dist <= 6; dist++) {
+        for (int dist = 1; dist <= 8; dist++) {
             data.index[size][dist] = index;
             // top row, from x=0
             for (y = -dist, x = 0; x < size + dist; x++, index++) {


### PR DESCRIPTION
In the original c3_model file, the Senate and Forts have a desirability radius of 8, but due to a couple of lines of code, it gets trimmed down to 6.
![2025-06-09_223743](https://github.com/user-attachments/assets/e48347b9-7f1f-46a9-abc4-6ee96b229006)
![2025-06-10_164322](https://github.com/user-attachments/assets/b20122cc-7714-4915-a040-08d41a82bbab)
I fixed that.

I also increased the desirability radius for all GTs and the Pantheon from 5 to 8.

![2025-06-09_232113](https://github.com/user-attachments/assets/a92b1d79-e70c-45c9-b4a4-50bf56438e15)
![2025-06-09_232158](https://github.com/user-attachments/assets/98601fe5-c007-4a45-9be9-fbdcd04219d4)
