### PR TITLE
FIX Auto-cycle button disappears from time to time

### DIFF
--- a/src/building/menu.c
+++ b/src/building/menu.c
@@ -106,10 +106,7 @@ static void enable_clear(int *enabled, building_type menu_building_type)
 static void enable_cycling_temples_if_allowed(building_type type)
 {
     int sub = (type == BUILDING_MENU_SMALL_TEMPLES) ? BUILD_MENU_SMALL_TEMPLES : BUILD_MENU_LARGE_TEMPLES;
-    menu_enabled[sub][0] = 0;
-    if (building_menu_count_items(sub) > 1) {
-        menu_enabled[sub][0] = 1;
-    }
+    menu_enabled[sub][0] = 1;
 }
 
 static int is_building_type_allowed(building_type type);


### PR DESCRIPTION
On my map, the button that was missing for small and large temples has reappeared