### PR TITLE
Green Elevated highlight for employees of a selected building

### DIFF
--- a/src/graphics/color.h
+++ b/src/graphics/color.h
@@ -65,6 +65,7 @@ typedef uint32_t color_t;
 
 #define COLOR_MASK_TYRIAN_PURPLE 0xff66023C
 #define COLOR_MASK_LIGHT_BLUE 0xff3552ff
+#define COLOR_MASK_SKY_BLUE 0xff90aaff
 #define COLOR_MASK_POSITIVE_RANGE 0x80005100    //50% transparent DARK_GREEN
 #define COLOR_MASK_NEGATIVE_RANGE 0x40ff0000    //25% transparent COLOR_RED
 

--- a/src/graphics/screenshot.c
+++ b/src/graphics/screenshot.c
@@ -107,7 +107,7 @@ static const char *generate_filename(screenshot_type type)
         default:
             strftime(filename, FILE_NAME_MAX, "city %Y-%m-%d %H.%M.%S.png", loctime);
             break;
-    }    
+    }
     return dir_append_location(filename, PATH_LOCATION_SCREENSHOT);
 }
 
@@ -292,7 +292,7 @@ static void create_full_city_screenshot(void)
     int min_width = (GRID_SIZE * TILE_X_SIZE - city_width_pixels) / 2 + TILE_X_SIZE;
     int max_height = (GRID_SIZE * TILE_Y_SIZE + city_height_pixels) / 2;
     int min_height = max_height - city_height_pixels - TILE_Y_SIZE;
-    map_tile dummy_tile = {0, 0, 0};
+    map_tile dummy_tile = { 0, 0, 0 };
     int error = 0;
     int base_height = image_set_loop_height_limits(min_height, max_height);
     int size;
@@ -305,7 +305,7 @@ static void create_full_city_screenshot(void)
     int current_height = base_height;
     while ((size = image_request_rows()) != 0) {
         int y_offset = current_height + IMAGE_HEIGHT_CHUNK > max_height ?
-            IMAGE_HEIGHT_CHUNK - (max_height - current_height) - TILE_Y_SIZE: 0;
+            IMAGE_HEIGHT_CHUNK - (max_height - current_height) - TILE_Y_SIZE : 0;
         for (int width = 0; width < city_width_pixels; width += canvas_width) {
             int image_section_width = canvas_width;
             int x_offset = 0;
@@ -314,7 +314,7 @@ static void create_full_city_screenshot(void)
                 x_offset = canvas_width - image_section_width - TILE_X_SIZE * 2;
             }
             city_view_set_camera_from_pixel_position(min_width + width, current_height);
-            city_without_overlay_draw(0, 0, &dummy_tile);
+            city_without_overlay_draw(0, 0, &dummy_tile, 0);
             graphics_renderer()->save_screen_buffer(&canvas[width], x_offset, TOP_MENU_HEIGHT + y_offset,
                 image_section_width, IMAGE_HEIGHT_CHUNK - y_offset, city_width_pixels);
         }

--- a/src/widget/city.c
+++ b/src/widget/city.c
@@ -43,6 +43,8 @@
 #include "window/building_info.h"
 #include "window/city.h"
 
+#define NO_POSITION ((unsigned int)-1)
+
 static struct {
     map_tile current_tile;
     map_tile selected_tile;
@@ -91,7 +93,7 @@ void widget_city_draw(void)
     update_zoom_level();
     set_city_clip_rectangle();
     if (game_state_overlay()) {
-        city_with_overlay_draw(&data.current_tile);
+        city_with_overlay_draw(&data.current_tile, data.selected_building_id);
     } else {
         city_without_overlay_draw(0, 0, &data.current_tile, data.selected_building_id);
     }
@@ -651,6 +653,8 @@ static void handle_mouse(const mouse *m)
             return;
         }
         if (handle_right_click_allow_building_info(tile)) {
+            int building_id = map_building_at(tile->grid_offset);
+            data.selected_building_id = building_id ? building_id : NO_POSITION; //no position if selected 0
             window_building_info_show(tile->grid_offset);
             return;
         }
@@ -793,11 +797,14 @@ void widget_city_clear_current_tile(void)
     data.selected_tile.grid_offset = 0;
     data.current_tile.grid_offset = 0;
     data.routing_grid_offset = 0;
+    data.selected_building_id = NO_POSITION;
+
 }
 
 void widget_city_clear_routing_grid_offset(void)
 {
     data.routing_grid_offset = 0;
+    data.selected_building_id = NO_POSITION;
 }
 
 void widget_city_setup_routing_preview(void)
@@ -808,13 +815,14 @@ void widget_city_setup_routing_preview(void)
     }
 
     int building_id = map_building_at(data.routing_grid_offset);
-    data.selected_building_id = building_id;
+
     if (building_id) {
+        data.selected_building_id = building_id;
         building *b = building_main(building_get(building_id));
         figure_roamer_preview_reset(b->type);
         figure_roamer_preview_create(b->type, b->x, b->y);
     } else {
-        data.selected_building_id = 0;
+        data.selected_building_id = NO_POSITION;
         figure_roamer_preview_reset(building_construction_type());
     }
 }

--- a/src/widget/city_figure.c
+++ b/src/widget/city_figure.c
@@ -19,7 +19,7 @@ static color_t get_highlight_mask(int highlight_mask)
     }
 }
 
-static void draw_figure_with_cart(const figure *f, int x, int y, float scale)
+static void draw_figure_with_cart(const figure *f, int x, int y, color_t color_mask, float scale)
 {
     if (f->y_offset_cart >= 0) {
         image_draw(f->image_id, x, y, COLOR_MASK_NONE, scale);
@@ -30,7 +30,7 @@ static void draw_figure_with_cart(const figure *f, int x, int y, float scale)
     }
 }
 
-static void draw_hippodrome_horse(const figure *f, int x, int y, float scale)
+static void draw_hippodrome_horse(const figure *f, int x, int y, color_t color_mask, float scale)
 {
     int val = f->wait_ticks_missile;
     switch (city_view_orientation()) {
@@ -110,7 +110,7 @@ static void draw_hippodrome_horse(const figure *f, int x, int y, float scale)
             }
             break;
     }
-    draw_figure_with_cart(f, x, y, scale);
+    draw_figure_with_cart(f, x, y, color_mask, scale);
 }
 
 static void draw_fort_standard(const figure *f, int x, int y, float scale)
@@ -259,6 +259,7 @@ static void adjust_pixel_offset(const figure *f, int *pixel_x, int *pixel_y)
 
 static void draw_figure(const figure *f, int x, int y, float scale, int highlight)
 {
+    color_t color_mask = get_highlight_mask(highlight);
     if (f->cart_image_id) {
         switch (f->type) {
             case FIGURE_CART_PUSHER:
@@ -270,10 +271,10 @@ static void draw_figure(const figure *f, int x, int y, float scale, int highligh
             case FIGURE_IMMIGRANT:
             case FIGURE_EMIGRANT:
             case FIGURE_LIGHTHOUSE_SUPPLIER:
-                draw_figure_with_cart(f, x, y, scale);
+                draw_figure_with_cart(f, x, y, color_mask, scale);
                 break;
             case FIGURE_HIPPODROME_HORSES:
-                draw_hippodrome_horse(f, x, y, scale);
+                draw_hippodrome_horse(f, x, y, color_mask, scale);
                 break;
             case FIGURE_FORT_STANDARD:
                 draw_fort_standard(f, x, y, scale);
@@ -282,14 +283,14 @@ static void draw_figure(const figure *f, int x, int y, float scale, int highligh
                 draw_map_flag(f, x, y, scale);
                 break;
             default:
-                image_draw(f->image_id, x, y, 0, scale);
+                image_draw(f->image_id, x, y, color_mask, scale);
                 break;
         }
     } else {
         if (f->is_enemy_image) {
             image_draw_enemy(f->image_id, x, y, scale);
         } else {
-            color_t color_mask = get_highlight_mask(highlight);
+
             image_draw(f->image_id, x, y, color_mask, scale);
         }
     }

--- a/src/widget/city_figure.c
+++ b/src/widget/city_figure.c
@@ -16,17 +16,19 @@ static color_t get_highlight_mask(int highlight_mask)
             return COLOR_MASK_LEGION_HIGHLIGHT;
         case FIGURE_HIGHLIGHT_GREEN:
             return COLOR_MASK_GREEN;
+        default:
+            return COLOR_MASK_NONE;
     }
 }
 
 static void draw_figure_with_cart(const figure *f, int x, int y, color_t color_mask, float scale)
 {
     if (f->y_offset_cart >= 0) {
-        image_draw(f->image_id, x, y, COLOR_MASK_NONE, scale);
-        image_draw(f->cart_image_id, x + f->x_offset_cart, y + f->y_offset_cart, COLOR_MASK_NONE, scale);
+        image_draw(f->image_id, x, y, color_mask, scale);
+        image_draw(f->cart_image_id, x + f->x_offset_cart, y + f->y_offset_cart, color_mask, scale);
     } else {
-        image_draw(f->cart_image_id, x + f->x_offset_cart, y + f->y_offset_cart, COLOR_MASK_NONE, scale);
-        image_draw(f->image_id, x, y, COLOR_MASK_NONE, scale);
+        image_draw(f->cart_image_id, x + f->x_offset_cart, y + f->y_offset_cart, color_mask, scale);
+        image_draw(f->image_id, x, y, color_mask, scale);
     }
 }
 

--- a/src/widget/city_figure.c
+++ b/src/widget/city_figure.c
@@ -7,6 +7,18 @@
 #include "graphics/image.h"
 #include "graphics/text.h"
 
+static color_t get_highlight_mask(int highlight_mask)
+{
+    switch (highlight_mask) {
+        case FIGURE_HIGHLIGHT_NONE:
+            return COLOR_MASK_NONE;
+        case FIGURE_HIGHLIGHT_RED:
+            return COLOR_MASK_LEGION_HIGHLIGHT;
+        case FIGURE_HIGHLIGHT_GREEN:
+            return COLOR_MASK_GREEN;
+    }
+}
+
 static void draw_figure_with_cart(const figure *f, int x, int y, float scale)
 {
     if (f->y_offset_cart >= 0) {
@@ -277,7 +289,8 @@ static void draw_figure(const figure *f, int x, int y, float scale, int highligh
         if (f->is_enemy_image) {
             image_draw_enemy(f->image_id, x, y, scale);
         } else {
-            image_draw(f->image_id, x, y, highlight ? COLOR_MASK_LEGION_HIGHLIGHT : COLOR_MASK_NONE, scale);
+            color_t color_mask = get_highlight_mask(highlight);
+            image_draw(f->image_id, x, y, color_mask, scale);
         }
     }
 }

--- a/src/widget/city_figure.h
+++ b/src/widget/city_figure.h
@@ -8,7 +8,7 @@ enum {
     FIGURE_HIGHLIGHT_NONE = 0,
     FIGURE_HIGHLIGHT_RED = 1,
     FIGURE_HIGHLIGHT_GREEN = 2,
-}highlight_mask;
+};
 
 void city_draw_figure(const figure *f, int x, int y, float scale, int highlight);
 

--- a/src/widget/city_figure.h
+++ b/src/widget/city_figure.h
@@ -4,6 +4,12 @@
 #include "figure/figure.h"
 #include "widget/city.h"
 
+enum {
+    FIGURE_HIGHLIGHT_NONE = 0,
+    FIGURE_HIGHLIGHT_RED = 1,
+    FIGURE_HIGHLIGHT_GREEN = 2,
+}highlight_mask;
+
 void city_draw_figure(const figure *f, int x, int y, float scale, int highlight);
 
 void city_draw_selected_figure(const figure *f, int x, int y, float scale, pixel_coordinate *coord);

--- a/src/widget/city_with_overlay.h
+++ b/src/widget/city_with_overlay.h
@@ -9,7 +9,7 @@
  */
 void city_with_overlay_update(void);
 
-void city_with_overlay_draw(const map_tile *tile);
+void city_with_overlay_draw(const map_tile *tile, unsigned int roamer_preview_building_id);
 
 int city_with_overlay_get_tooltip_text(tooltip_context *c, int grid_offset);
 

--- a/src/widget/city_without_overlay.c
+++ b/src/widget/city_without_overlay.c
@@ -73,6 +73,7 @@ static struct {
     int image_id_water_last;
     int selected_figure_id;
     int highlighted_formation;
+    int selected_building_id;
     pixel_coordinate *selected_figure_coord;
 
     float scale;
@@ -769,11 +770,20 @@ static void draw_animation(int x, int y, int grid_offset)
 static void draw_elevated_figures(int x, int y, int grid_offset)
 {
     int figure_id = map_figure_at(grid_offset);
+
+
     while (figure_id > 0) {
         figure *f = figure_get(figure_id);
+
         if ((f->use_cross_country && !f->is_ghost && !f->dont_draw_elevated) || f->height_adjusted_ticks) {
             int highlight = f->formation_id > 0 && f->formation_id == draw_context.highlighted_formation;
             city_draw_figure(f, x, y, draw_context.scale, highlight);
+        } else if (f->building_id == draw_context.selected_building_id) { //figure originates from selected building
+            if (config_get(CONFIG_UI_SHOW_ROAMING_PATH)) {
+                int highlight = FIGURE_HIGHLIGHT_GREEN;
+                city_draw_figure(f, x, y, draw_context.scale, highlight);
+            }
+
         }
         figure_id = f->next_figure_id_on_same_tile;
     }
@@ -954,10 +964,13 @@ static void update_clouds(void)
  }
  ***/
 
-void city_without_overlay_draw(int selected_figure_id, pixel_coordinate *figure_coord, const map_tile *tile)
+void city_without_overlay_draw(int selected_figure_id, pixel_coordinate *figure_coord, const map_tile *tile, int roamer_preview_building_id)
 {
     int highlighted_formation_id = get_highlighted_formation_id(tile);
     init_draw_context(selected_figure_id, figure_coord, highlighted_formation_id);
+    if (roamer_preview_building_id) {
+        draw_context.selected_building_id = roamer_preview_building_id;//store the clicked building id
+    }
     int x, y, width, height;
     city_view_get_viewport(&x, &y, &width, &height);
     graphics_fill_rect(x, y, width, height, COLOR_BLACK);

--- a/src/widget/city_without_overlay.c
+++ b/src/widget/city_without_overlay.c
@@ -374,7 +374,10 @@ static void draw_top(int x, int y, int grid_offset)
     color_t color_mask = 0;
     if (draw_building_as_deleted(b) || (map_property_is_deleted(grid_offset) && !is_multi_tile_terrain(grid_offset))) {
         color_mask = COLOR_MASK_RED;
+    } else if (b->id == draw_context.selected_building_id) {
+        color_mask = COLOR_MASK_GREEN;
     }
+
     image_draw_isometric_top_from_draw_tile(image_id, x, y, color_mask, draw_context.scale);
     // specific buildings
     draw_senate_rating_flags(b, x, y, color_mask);

--- a/src/widget/city_without_overlay.h
+++ b/src/widget/city_without_overlay.h
@@ -4,6 +4,6 @@
 #include "map/point.h"
 #include "widget/city.h"
 
-void city_without_overlay_draw(int selected_figure_id, pixel_coordinate *figure_coord, const map_tile *tile);
+void city_without_overlay_draw(int selected_figure_id, pixel_coordinate *figure_coord, const map_tile *tile, int roamer_preview_building_id);
 
 #endif // WIDGET_CITY_WITHOUT_OVERLAY_H

--- a/src/widget/city_without_overlay.h
+++ b/src/widget/city_without_overlay.h
@@ -4,6 +4,7 @@
 #include "map/point.h"
 #include "widget/city.h"
 
-void city_without_overlay_draw(int selected_figure_id, pixel_coordinate *figure_coord, const map_tile *tile, int roamer_preview_building_id);
+void city_without_overlay_draw(int selected_figure_id, pixel_coordinate *figure_coord,
+                            const map_tile *tile, unsigned int roamer_preview_building_id);
 
 #endif // WIDGET_CITY_WITHOUT_OVERLAY_H


### PR DESCRIPTION
Selecting a building with roamer preview on now elevates and colours green the workers of this building, so you can easily track your market ladies!
![image](https://github.com/user-attachments/assets/b2c24bef-e51a-461d-945e-23ecee49a093)
![image](https://github.com/user-attachments/assets/ab6acdef-b14d-4ad2-a4ff-43ec475f1cf1)
