### PR TITLE
Non-draggable reservoir over aqueducts

### DIFF
--- a/src/building/construction_building.c
+++ b/src/building/construction_building.c
@@ -351,6 +351,8 @@ int building_construction_place_building(building_type type, int x, int y)
         //allow building gatehouses over walls and roads, other non-bridge roadblocks over roads and highways
     } else if (type == BUILDING_TOWER) {
         terrain_mask = ~TERRAIN_WALL;
+    } else if (type == BUILDING_RESERVOIR || type == BUILDING_DRAGGABLE_RESERVOIR) {
+        terrain_mask = ~TERRAIN_AQUEDUCT;
     }
     if (config_get(CONFIG_GP_CH_WAREHOUSES_GRANARIES_OVER_ROAD_PLACEMENT)) {
         if (type == BUILDING_GRANARY || type == BUILDING_WAREHOUSE) {

--- a/src/map/routing.c
+++ b/src/map/routing.c
@@ -26,7 +26,7 @@ typedef enum {
 static const int ROUTE_OFFSETS[] = { -162, 1, 162, -1, -161, 163, 161, -163 };
 static const int ROUTE_OFFSETS_X[] = { 0, 1, 0, -1,  1, 1, -1, -1 };
 static const int ROUTE_OFFSETS_Y[] = { -1, 0, 1,  0, -1, 1,  1, -1 };
-static const int HIGHWAY_DIRECTIONS[] = { 
+static const int HIGHWAY_DIRECTIONS[] = {
     TERRAIN_HIGHWAY_TOP_RIGHT | TERRAIN_HIGHWAY_BOTTOM_RIGHT, // up
     TERRAIN_HIGHWAY_BOTTOM_LEFT | TERRAIN_HIGHWAY_BOTTOM_RIGHT, // right
     TERRAIN_HIGHWAY_TOP_LEFT | TERRAIN_HIGHWAY_BOTTOM_LEFT, // down
@@ -410,6 +410,20 @@ static int callback_calc_distance_build_aqueduct(int next_offset, int dist, int 
     return 1;
 }
 
+static int map_can_place_initial_reservoir(int grid_offset)
+{
+    if (map_terrain_is(grid_offset, TERRAIN_AQUEDUCT)) {
+        return 1;
+    } else if (map_terrain_is(grid_offset, TERRAIN_BUILDING)) {
+        if (building_get(map_building_at(grid_offset))->type == BUILDING_RESERVOIR) {
+            return 1;
+        }
+    } else {
+        return 0;
+    }
+
+}
+
 static int map_can_place_initial_road_or_aqueduct(int grid_offset, int is_aqueduct)
 {
     if (is_aqueduct && !map_can_place_aqueduct_on_highway(grid_offset, 0)) {
@@ -464,7 +478,14 @@ int map_routing_calculate_distances_for_building(routed_building_type type, int 
         route_queue_all_from(source_offset, DIRECTIONS_NO_DIAGONALS, callback_calc_distance_build_highway, 0);
         return 1;
     }
+    if (type == BUILDING_DRAGGABLE_RESERVOIR) {
+        if (map_can_place_initial_reservoir(source_offset)) {
+            return 1;
+        } else {
+            return 0;
+        }
 
+    }
     if (!map_can_place_initial_road_or_aqueduct(source_offset, type != ROUTED_BUILDING_ROAD)) {
         return 0;
     }


### PR DESCRIPTION
Allows a placement of a single reservoir directly over aqueducts, in the same fashion as new granary-over-road placement.
Reservoir placed this way cannot be dragged, but regular reservoir placements still can.
After that reservoir is placed, another can be placed 'on top of it' to drag it, just like the current behaviour.

!**This is done on request and I didn't have time to test it thoroughly**!
!**Please test this before merging**!