### PR TITLE
Fallback added for missing OG translation fix  keys

### DIFF
--- a/src/core/lang.c
+++ b/src/core/lang.c
@@ -91,7 +91,10 @@ static uint8_t *get_message_text(int32_t offset)
     //locale-dependent fixes
     language_type l_type = locale_last_determined_language();
     if (l_type == LANGUAGE_GERMAN && offset == 289) {
-        return (uint8_t *) translation_for(TR_FIX_GERMAN_CITY_RETAKEN);
+        const uint8_t *try_translation = translation_for(TR_FIX_GERMAN_CITY_RETAKEN);
+        if (try_translation) {
+            return try_translation;
+        }
     }
     return &data.message_data[offset];
 }
@@ -357,7 +360,10 @@ const uint8_t *lang_get_string(int group, int index)
     //locale-dependent fixes
     language_type l_type = locale_last_determined_language();
     if (l_type == LANGUAGE_KOREAN && group == 28 && index == 46) {
-        return translation_for(TR_FIX_KOREAN_BUILDING_DOCTORS_CLINIC);
+        const uint8_t *try_translation = translation_for(TR_FIX_KOREAN_BUILDING_DOCTORS_CLINIC);
+        if (try_translation) {
+            return try_translation;
+        }
     }
     //Custom translations
     if (group == CUSTOM_TRANSLATION) {


### PR DESCRIPTION
If TR_FIX key is missing, continue with default behaviour. 

<img width="884" height="214" alt="image" src="https://github.com/user-attachments/assets/c831607d-892a-45a8-8f17-683fec9d13a1" />
<img width="485" height="411" alt="image" src="https://github.com/user-attachments/assets/992e6965-bec2-4f0f-a2e3-c5b500184fac" />
