### PR TITLE
Storage bugfixes

### DIFF
--- a/src/building/warehouse.c
+++ b/src/building/warehouse.c
@@ -787,7 +787,7 @@ int building_warehouse_determine_worker_task(building *warehouse, int *resource)
         int fetch_amount = MAX_CARTLOADS_PER_SPACE;
 
 
-        if (available > needed && needed >= fetch_amount && fetch_amount > 0) {
+        if (needed >= fetch_amount && fetch_amount > 0) {
             if (!building_warehouse_for_getting(warehouse, r, 0)) {
                 continue;
             }

--- a/src/building/warehouse.c
+++ b/src/building/warehouse.c
@@ -81,7 +81,7 @@ int building_warehouse_add_resource(building *b, int resource, int respect_setti
     if (b->id <= 0) {
         return 0;
     }
-    if (respect_settings && building_warehouse_is_not_accepting(resource, building_main(b))) {
+    if (respect_settings && building_warehouse_maximum_receptible_amount(resource, building_main(b)) <= 0) {
         return 0;
     }
     // Fill partially filled bays first
@@ -563,7 +563,8 @@ int building_warehouse_for_storing(int src_building_id, int x, int y, int resour
     int min_building_id = 0;
     for (building *b = building_first_of_type(BUILDING_WAREHOUSE); b; b = b->next_of_type) {
         if (b->id == src_building_id || (road_network_id != -1 && b->road_network_id != road_network_id) ||
-            !building_warehouse_accepts_storage(b, resource, understaffed)) {
+            !building_warehouse_accepts_storage(b, resource, understaffed) ||
+            (building_warehouse_maximum_receptible_amount(resource, b) <= 0)) {
             continue;
         }
         int dist = calc_maximum_distance(b->x, b->y, x, y);

--- a/src/window/building/depot.c
+++ b/src/window/building/depot.c
@@ -509,8 +509,12 @@ static void order_set_resource(const generic_button *button)
 
 void window_building_depot_get_tooltip_main(int *translation)
 {
-    if (data.focus_button_id < 6) {
+
+    if (data.focus_button_id < 5) {
         return;
+    }
+    if (data.focus_button_id == 5) {
+        *translation = TR_TOOLTIP_RIGHT_CLICK_TO_DECREASE;
     }
     const building *depot = building_get(data.depot_building_id);
     if (!depot) {


### PR DESCRIPTION
- Fixed a bug where a warehouse would not get goods if maximum available amount in the city was less than pursued amount
- Fixed a bug where a warehouse would allow temporary overload of accepting/retaining/getting quantity, if cartpusher left origin before the warehouse filled up
- Fixed cart depot not having the 'Rightclick to decrease quantity' tooltip