### PR TITLE
Add all labor buildings to the data transfer to copy mothball status from them 

### DIFF
--- a/src/building/data_transfer.c
+++ b/src/building/data_transfer.c
@@ -74,6 +74,9 @@ int building_data_transfer_copy(building *b)
         case DATA_TYPE_RAW_RESOURCE_PRODUCER:
             data.i8 = b->data.industry.is_stockpiling;
             break;
+        case DATA_TYPE_MOTHBALL_ONLY:
+            // Mothball state is already set in data.mothball
+            break;
         default:
             return 0;
 

--- a/src/building/data_transfer.c
+++ b/src/building/data_transfer.c
@@ -1,5 +1,6 @@
 #include "data_transfer.h"
 
+#include "building/building.h"
 #include "building/industry.h"
 #include "building/roadblock.h"
 #include "building/storage.h"
@@ -112,6 +113,8 @@ int building_data_transfer_paste(building *b)
         case DATA_TYPE_RAW_RESOURCE_PRODUCER:
             b->data.industry.is_stockpiling = data.i8;
             break;
+        case DATA_TYPE_MOTHBALL_ONLY:
+            break;
         default:
             return 0;
     }
@@ -146,6 +149,11 @@ building_data_type building_data_transfer_data_type_from_building_type(building_
         case BUILDING_DEPOT:
             return DATA_TYPE_DEPOT;
         default:
-            return DATA_TYPE_NOT_SUPPORTED;
+            if (building_get_laborers(type)) {
+                return DATA_TYPE_MOTHBALL_ONLY;
+            } else {
+                return DATA_TYPE_NOT_SUPPORTED;
+            }
+
     }
 }

--- a/src/building/data_transfer.c
+++ b/src/building/data_transfer.c
@@ -17,6 +17,7 @@ static struct {
     short i16;
     int i32;
     signed char mothball;
+    building_type b_type;
 } data;
 
 int building_data_transfer_possible(building *b)
@@ -27,6 +28,10 @@ int building_data_transfer_possible(building *b)
         return 0;
     }
     if (data.data_type != data_type) {
+        city_warning_show(WARNING_DATA_PASTE_FAILURE, NEW_WARNING_SLOT);
+        return 0;
+    }
+    if (data.data_type == DATA_TYPE_MOTHBALL_ONLY && b->type != data.b_type) {
         city_warning_show(WARNING_DATA_PASTE_FAILURE, NEW_WARNING_SLOT);
         return 0;
     }
@@ -45,6 +50,7 @@ int building_data_transfer_copy(building *b)
 
     const building_storage *storage;
     data.mothball = b->state == BUILDING_STATE_MOTHBALLED ? 1 : 0;
+    data.b_type = b->type;
     switch (data_type) {
         case DATA_TYPE_ROADBLOCK:
             data.i16 = b->data.roadblock.exceptions;

--- a/src/building/data_transfer.h
+++ b/src/building/data_transfer.h
@@ -12,7 +12,8 @@ typedef enum {
     DATA_TYPE_TAVERN,
     DATA_TYPE_ROADBLOCK,
     DATA_TYPE_DEPOT,
-    DATA_TYPE_RAW_RESOURCE_PRODUCER
+    DATA_TYPE_RAW_RESOURCE_PRODUCER,
+    DATA_TYPE_MOTHBALL_ONLY, // for buildings that can only have one setting - mothballed or not
 } building_data_type;
 
 int building_data_transfer_copy(building *b);


### PR DESCRIPTION
Currently all buildings not included in standard data types are not allowed to copy settings from. 
This PR adds that option, even if it's only mothball status.

Let them in on the fun.