### PR TITLE
Draw right desirability range if VenusGT is built

### DIFF
--- a/src/widget/city_building_ghost.c
+++ b/src/widget/city_building_ghost.c
@@ -453,6 +453,13 @@ static void draw_desirability_range(const map_tile *tile, building_type type, in
     if (desirability_value == 0 || desirability_range == 0) {
         return;         // If there is no desirability - do not draw
     }
+    
+    if (building_is_statue_garden_temple(type) && building_monument_working(BUILDING_GRAND_TEMPLE_VENUS)) {
+        int value_bonus = ((desirability_value / 4) > 1) ? (desirability_value / 4) : 1;
+        desirability_value += value_bonus;
+        desirability_range += 1;
+    }
+    
     // Calculating the Radius of Negative Desirability
     while (desirability_value < 0 && negative_range < desirability_range) {
         desirability_value += desirability_step_size;

--- a/src/widget/city_building_ghost.c
+++ b/src/widget/city_building_ghost.c
@@ -457,7 +457,9 @@ static void draw_desirability_range(const map_tile *tile, building_type type, in
     if (building_is_statue_garden_temple(type) && building_monument_working(BUILDING_GRAND_TEMPLE_VENUS)) {
         int value_bonus = ((desirability_value / 4) > 1) ? (desirability_value / 4) : 1;
         desirability_value += value_bonus;
-        desirability_range += 1;
+        if (!(type >= BUILDING_GRAND_TEMPLE_CERES && type <= BUILDING_GRAND_TEMPLE_VENUS)) {
+            desirability_range += 1;
+        }
     }
     
     // Calculating the Radius of Negative Desirability


### PR DESCRIPTION
Can someone tell me why the range of GTs is not adjusted by the Venus base bonus, although building_is_statue_garden_temple() is including GTs ?