### PR TITLE
Road visuals small update

### DIFF
--- a/src/building/construction_building.c
+++ b/src/building/construction_building.c
@@ -128,6 +128,7 @@ static void add_warehouse(building *b)
     game_undo_adjust_building(b);
 
     building_get(prev)->next_part_building_id = 0;
+    map_tiles_update_area_roads(b->x, b->y, 5);
 }
 
 static void add_building(building *b)

--- a/src/map/tiles.c
+++ b/src/map/tiles.c
@@ -685,18 +685,22 @@ int map_tiles_set_wall(int x, int y)
     return tile_set;
 }
 
-int map_tiles_is_adjacent_to_building_type(int grid_offset, int building_type)
+int map_tiles_is_adjacent_to_building_type(int grid_offset, int building_type, int diagonals_included)
 {
+
     int tiles[8];
     tiles[0] = grid_offset + map_grid_delta(0, -1);
     tiles[1] = grid_offset + map_grid_delta(1, 0);
     tiles[2] = grid_offset + map_grid_delta(0, 1);
     tiles[3] = grid_offset + map_grid_delta(-1, 0);
-    tiles[4] = grid_offset + map_grid_delta(1, -1);
+    tiles[4] = grid_offset + map_grid_delta(1, -1);// diagonal tiles 
     tiles[5] = grid_offset + map_grid_delta(1, 1);
     tiles[6] = grid_offset + map_grid_delta(-1, 1);
     tiles[7] = grid_offset + map_grid_delta(-1, -1);
     for (int i = 0; i < 8; i++) {
+        if (!diagonals_included && i >= 4) {
+            break; // skip checking diagonal tiles if not included
+        }
         if (map_terrain_is(tiles[i], TERRAIN_BUILDING) &&
             building_get(map_building_at(tiles[i]))->type == building_type) {
             return 1;
@@ -714,7 +718,7 @@ int map_tiles_is_paved_road(int grid_offset)
     if (desirability > 0 && map_terrain_is(grid_offset, TERRAIN_FOUNTAIN_RANGE)) {
         return 1;
     }
-    if (map_tiles_is_adjacent_to_building_type(grid_offset, BUILDING_GRANARY)) {
+    if (map_tiles_is_adjacent_to_building_type(grid_offset, BUILDING_GRANARY, 1)) {
         return 1;
     }
     int x = map_grid_offset_to_x(grid_offset);

--- a/src/map/tiles.c
+++ b/src/map/tiles.c
@@ -685,6 +685,26 @@ int map_tiles_set_wall(int x, int y)
     return tile_set;
 }
 
+int map_tiles_is_adjacent_to_building_type(int grid_offset, int building_type)
+{
+    int tiles[8];
+    tiles[0] = grid_offset + map_grid_delta(0, -1);
+    tiles[1] = grid_offset + map_grid_delta(1, 0);
+    tiles[2] = grid_offset + map_grid_delta(0, 1);
+    tiles[3] = grid_offset + map_grid_delta(-1, 0);
+    tiles[4] = grid_offset + map_grid_delta(1, -1);
+    tiles[5] = grid_offset + map_grid_delta(1, 1);
+    tiles[6] = grid_offset + map_grid_delta(-1, 1);
+    tiles[7] = grid_offset + map_grid_delta(-1, -1);
+    for (int i = 0; i < 8; i++) {
+        if (map_terrain_is(tiles[i], TERRAIN_BUILDING) &&
+            building_get(map_building_at(tiles[i]))->type == building_type) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 int map_tiles_is_paved_road(int grid_offset)
 {
     int desirability = map_desirability_get(grid_offset);
@@ -692,6 +712,9 @@ int map_tiles_is_paved_road(int grid_offset)
         return 1;
     }
     if (desirability > 0 && map_terrain_is(grid_offset, TERRAIN_FOUNTAIN_RANGE)) {
+        return 1;
+    }
+    if (map_tiles_is_adjacent_to_building_type(grid_offset, BUILDING_GRANARY)) {
         return 1;
     }
     int x = map_grid_offset_to_x(grid_offset);

--- a/src/map/tiles.h
+++ b/src/map/tiles.h
@@ -13,7 +13,7 @@ void map_tiles_update_all_plazas(void);
 void map_tiles_update_all_walls(void);
 void map_tiles_update_area_walls(int x, int y, int size);
 int map_tiles_set_wall(int x, int y);
-
+int map_tiles_is_adjacent_to_building_type(int grid_offset, int building_type);
 int map_tiles_is_paved_road(int grid_offset);
 void map_tiles_update_all_roads(void);
 void map_tiles_update_area_roads(int x, int y, int size);

--- a/src/map/tiles.h
+++ b/src/map/tiles.h
@@ -13,7 +13,7 @@ void map_tiles_update_all_plazas(void);
 void map_tiles_update_all_walls(void);
 void map_tiles_update_area_walls(int x, int y, int size);
 int map_tiles_set_wall(int x, int y);
-int map_tiles_is_adjacent_to_building_type(int grid_offset, int building_type);
+int map_tiles_is_adjacent_to_building_type(int grid_offset, int building_type, int diagonals_included);
 int map_tiles_is_paved_road(int grid_offset);
 void map_tiles_update_all_roads(void);
 void map_tiles_update_area_roads(int x, int y, int size);


### PR DESCRIPTION
All roads adjacent to granary will now appear paved. This is to improve road visibility, since granary model tends to obscure it, as well as visual consistency with the paved footprint of the granary.
Also fixed a bug where the road through warehouse wouldn't update until map rotated or time in game passed.

### Before:
<img width="844" height="645" alt="Zrzut ekranu 2025-08-01 124153" src="https://github.com/user-attachments/assets/57d8f8a1-64ee-47b2-8727-79f0b818bb1e" />
<img width="668" height="435" alt="Zrzut ekranu 2025-08-01 124249" src="https://github.com/user-attachments/assets/ab8526fd-198a-400c-bd2d-e2531341a0a7" />

### After:
<img width="777" height="642" alt="Zrzut ekranu 2025-08-01 124219" src="https://github.com/user-attachments/assets/1963ddf1-7b59-4d61-911e-72713a6eb8e0" />


### Full road:
<img width="905" height="618" alt="Zrzut ekranu 2025-08-01 124104" src="https://github.com/user-attachments/assets/549d3daa-8456-42e1-b2af-d7752a45f3e6" />
