### PR TITLE
Hide terrain description when a figure is selected

### DIFF
--- a/src/window/building/distribution.c
+++ b/src/window/building/distribution.c
@@ -755,7 +755,7 @@ void window_building_draw_primary_product_stockpiling(building_info_context *c)
     int x = c->x_offset + primary_product_producer_button_stockpiling->x + BLOCK_SIZE * c->width_blocks - 40;
     int y = c->y_offset + primary_product_producer_button_stockpiling->y + 10;
     button_border_draw(x, y, 30, 30, data.primary_product_stockpiling_id);
-    image_draw(assets_get_image_id("UI", "Stockpile_Sprite"), x + 4, y + 6, building_stockpiling_enabled(building_get(c->building_id)) ?
+    image_draw(assets_get_image_id("UI", "Stockpile_Sprite"), x + 7, y + 6, building_stockpiling_enabled(building_get(c->building_id)) ?
     0xfff5a46b : COLOR_MASK_NONE, SCALE_NONE);
 }
 

--- a/src/window/building/terrain.c
+++ b/src/window/building/terrain.c
@@ -63,7 +63,10 @@ void window_building_draw_terrain(building_info_context *c)
             lang_text_draw_centered(70, c->terrain_type + 10,
                 c->x_offset, c->y_offset + 10, BLOCK_SIZE * c->width_blocks, FONT_LARGE_BLACK);
         }
-        if (c->terrain_type != TERRAIN_INFO_ROAD && c->terrain_type != TERRAIN_INFO_PLAZA && c->terrain_type != TERRAIN_INFO_HIGHWAY) {
+        if (c->figure.count == 0 &&
+            c->terrain_type != TERRAIN_INFO_ROAD &&
+            c->terrain_type != TERRAIN_INFO_PLAZA &&
+            c->terrain_type != TERRAIN_INFO_HIGHWAY) {
             lang_text_draw_multiline(70, c->terrain_type + 25,
                 c->x_offset + 40, c->y_offset + BLOCK_SIZE * c->height_blocks - 125,
                 BLOCK_SIZE * (c->width_blocks - 4), FONT_NORMAL_BLACK);


### PR DESCRIPTION
and offset for the new stockpiling icon


before
<img width="496" height="419" alt="2025-08-03_144654" src="https://github.com/user-attachments/assets/43414b34-ad36-402a-a62a-e33563030178" />
<img width="491" height="416" alt="2025-08-03_144644" src="https://github.com/user-attachments/assets/ce2e2271-a379-4fb0-a222-9beeb2e14c84" />


after
<img width="493" height="417" alt="2025-08-03_144600" src="https://github.com/user-attachments/assets/40e4e5b4-57d1-43e6-bbde-d6ccc7343f9e" />
<img width="479" height="407" alt="2025-08-03_144546" src="https://github.com/user-attachments/assets/9f04233d-189f-4dbe-961e-065f833988e0" />

