### PR TITLE
Mars curse invasions are now correctly random on custom maps

### DIFF
--- a/src/scenario/invasion.c
+++ b/src/scenario/invasion.c
@@ -12,6 +12,7 @@
 #include "figure/figure.h"
 #include "figure/formation.h"
 #include "figure/name.h"
+#include "game/campaign.h"
 #include "game/cheats.h"
 #include "game/difficulty.h"
 #include "game/time.h"
@@ -641,17 +642,14 @@ void scenario_invasion_process(void)
 int scenario_invasion_start_from_mars(void)
 {
     int mission = scenario_campaign_mission();
-    if (mission < 0 || mission > 19) {
-        mission = 0;
+    int amount;
+    if (game_campaign_is_original() && 0 <= mission && mission <= 19) {
+        amount = LOCAL_UPRISING_NUM_ENEMIES[mission];
+    } else {
+        amount = random_between_from_stdlib(3, 9);
     }
-    int amount = LOCAL_UPRISING_NUM_ENEMIES[mission];
     if (amount <= 0) {
-        // for custom mission
-        if (mission == 0) {
-            amount = random_between_from_stdlib(3, 9);
-        } else {
-            return 0;
-        }
+        return 0;
     }
     int grid_offset = start_invasion(ENEMY_0_BARBARIAN, amount, 8, FORMATION_ATTACK_FOOD_CHAIN, CHEATED_ARMY_ID);
     if (grid_offset) {

--- a/src/scenario/invasion.c
+++ b/src/scenario/invasion.c
@@ -323,6 +323,12 @@ static int start_invasion(int enemy_type, int amount, int invasion_point, format
     if (amount <= 0) {
         return -1;
     }
+
+    enemy_army *army = enemy_army_get_editable(invasion_id);
+    if (army) {
+        army->started_retreating = 0;
+    }
+
     int formations_per_type[3];
     int soldiers_per_formation[3][4];
     int x, y;

--- a/src/scenario/invasion.c
+++ b/src/scenario/invasion.c
@@ -645,8 +645,10 @@ int scenario_invasion_start_from_mars(void)
     int amount;
     if (game_campaign_is_original() && 0 <= mission && mission <= 19) {
         amount = LOCAL_UPRISING_NUM_ENEMIES[mission];
-    } else {
+    } else if(scenario_invasion_count_total() > 0) {
         amount = random_between_from_stdlib(3, 9);
+    } else {
+        amount = 0;
     }
     if (amount <= 0) {
         return 0;


### PR DESCRIPTION
Should fix #1403

`scenario_invasion_start_from_mars` did not check whether the current map was custom or not, so it applied the same code path for all maps even though it was originally designed for campaign only. Given that the campaign mission ID is not reset after launching the game, this ID was carried over new custom maps games after you played on a campaign mission, meaning that the Mars invasion actually depended on the previously played campaign mission.

The previous fix assumed that mission == 0 was equivalent to being on a custom map but it is actually the ID for the first campaign mission so it worked only when the last played mission was the first tutorial level.

Now on custom maps, it should correctly use an alternate code path that chooses a random number between 3 and 9 for the invasion force.

A few questions before merging though:
 - Maybe something could be done to make the mission ID use an alternate value on custom maps? Like -1 or something else? Not sure though since the current behavior dates back from the original C3 and this apparently hasn't caused any trouble besides this bug. Also this might require some changes throughout the code given the diverse usage of this ID.
 - This fix proposal assumes that the "random value between 3 and 9" was the behavior for all custom maps, wether you can train a military or not. On peaceful custom maps, I believe it could introduce some issues? Correct me if I am wrong.