### PR TITLE
FIX incorrect display of trader resource data v2

### DIFF
--- a/src/figure/figure.c
+++ b/src/figure/figure.c
@@ -75,6 +75,11 @@ figure *figure_create(figure_type type, int x, int y, direction_type dir)
 
 void figure_delete(figure *f)
 {
+    if (f->trader_id >= 0 &&
+    (f->type == FIGURE_TRADE_CARAVAN || f->type == FIGURE_TRADE_SHIP || f->type == FIGURE_NATIVE_TRADER)) {
+        trader_free(f->trader_id);
+        f->trader_id = -1;
+    }
     building *b = building_get(f->building_id);
     switch (f->type) {
         case FIGURE_LABOR_SEEKER:

--- a/src/figure/trader.c
+++ b/src/figure/trader.c
@@ -15,6 +15,8 @@ struct trader {
     int32_t sold_amount;
     int32_t sold_value;
     uint8_t sold_resources[RESOURCE_MAX];
+
+    int figure_id;
 };
 
 static struct {
@@ -24,18 +26,35 @@ static struct {
 
 void traders_clear(void)
 {
-    memset(&data, 0, sizeof(data));
+    for (int i = 0; i < MAX_TRADERS; i++) {
+        memset(&data.traders[i], 0, sizeof(struct trader));
+        data.traders[i].figure_id = -1;  // Mark as free
+    }
+    data.next_index = 0;
 }
 
 int trader_create(void)
-{
-    int trader_id = data.next_index++;
-    if (data.next_index >= MAX_TRADERS) {
-        data.next_index = 0;
+{                                                             // Clear commits after review
+    for (int i = 0; i < MAX_TRADERS; i++) {                   // Loop through all possible trader slots, up to MAX_TRADERS times
+        int trader_id = (data.next_index + i) % MAX_TRADERS;  // Calculate the current slot index, starting from data.next_index
+                                                              // Wrap around to the beginning if we reach the end of the array
+        if (data.traders[trader_id].figure_id == -1) {        // Check if the slot is free (figure_id == -1 means it's unused)
+            memset(&data.traders[trader_id], 0, sizeof(struct trader)); // Clear the memory of this trader slot to reset old data
+            data.traders[trader_id].figure_id = trader_id;    // Mark this slot as occupied by setting figure_id to its index
+            data.next_index = (trader_id + 1) % MAX_TRADERS;  // Update next_index to the next slot for faster future searches
+            return trader_id;                                 // Return the index of the newly created trader
+        }
     }
+    return -1;  // If no free slot was found, return -1 to indicate failure
+}
 
+void trader_free(int trader_id)
+{
+    if (trader_id < 0 || trader_id >= MAX_TRADERS) {
+        return;
+    }
     memset(&data.traders[trader_id], 0, sizeof(struct trader));
-    return trader_id;
+    data.traders[trader_id].figure_id = -1;  // Mark the slot as free
 }
 
 void trader_record_bought_resource(int trader_id, resource_type resource)

--- a/src/figure/trader.h
+++ b/src/figure/trader.h
@@ -91,4 +91,6 @@ void traders_save_state(buffer *buf);
  */
 void traders_load_state(buffer *buf);
 
+void trader_free(int trader_id);
+
 #endif // FIGURE_TRADE_INFO_H


### PR DESCRIPTION
 I’ve caught a bug (master branch).
 The land trader (near warehouse 12) bought 16 fish, but this also got duplicated in the trade ship window.
 
![2025-08-12_235835](https://github.com/user-attachments/assets/80abe786-fe41-4c0e-8418-01b05f9791c2)
![2025-08-12_235819](https://github.com/user-attachments/assets/11ea6416-aee3-431e-b18b-008bfc47c628)

[bug-tradeship-1may.zip](https://github.com/user-attachments/files/21773644/bug-tradeship-1may.zip)
