### PR TITLE
Fix tooltip text of ratings in the top menu panel

### DIFF
--- a/src/widget/top_menu.c
+++ b/src/widget/top_menu.c
@@ -867,20 +867,19 @@ int widget_top_menu_get_tooltip_text(tooltip_context *c)
             c->extra_text_groups[0] = 53;
             switch (button_id) {
                 case INFO_CULTURE:
-                    c->extra_text_ids[0] = (scenario_criteria_culture() <= 90)
+                    c->extra_text_ids[0] = (city_rating_culture() <= 90)
                         ? 9 + city_rating_explanation_for(SELECTED_RATING_CULTURE) : 50;
                     return 1;
-
                 case INFO_PROSPERITY:
-                    c->extra_text_ids[0] = (scenario_criteria_prosperity() <= 90)
+                    c->extra_text_ids[0] = (city_rating_prosperity() <= 90)
                         ? 16 + city_rating_explanation_for(SELECTED_RATING_PROSPERITY) : 51;
                     return 2;
                 case INFO_PEACE:
-                    c->extra_text_ids[0] = (scenario_criteria_peace() <= 90)
+                    c->extra_text_ids[0] = (city_rating_peace() <= 90)
                         ? 41 + city_rating_explanation_for(SELECTED_RATING_PEACE) : 52;
                     return 3;
                 case INFO_FAVOR:
-                    c->extra_text_ids[0] = (scenario_criteria_favor() <= 90)
+                    c->extra_text_ids[0] = (city_rating_favor() <= 90)
                         ? 27 + city_rating_explanation_for(SELECTED_RATING_FAVOR) : 53;
                     return 4;
                 case INFO_HEALTH:

--- a/src/widget/top_menu.c
+++ b/src/widget/top_menu.c
@@ -543,7 +543,7 @@ static int draw_health_panel(int offset, int box_width, font_t font)
 
     // center it in the box
     int x = offset + (box_width - health_w) / 2;
-    text_draw_number(health, ' ', "", x, 5, font, color);
+    text_draw_number(health, ' ', "", x + 10, 5, font, color);
 
     return box_width;
 }


### PR DESCRIPTION
before
![2025-08-25_113129](https://github.com/user-attachments/assets/436193d2-b4c8-45f3-80a0-48331dc4d3fe)

after
![2025-08-28_121915](https://github.com/user-attachments/assets/9260046a-354f-4a9b-b47c-46204928ee73)
