### PR TITLE
Make bridges countable

### DIFF
--- a/src/building/count.c
+++ b/src/building/count.c
@@ -502,22 +502,6 @@ int building_count_gardens_in_area(int minx, int miny, int maxx, int maxy, int o
     return total;
 }
 
-int building_count_bridges_in_area(int minx, int miny, int maxx, int maxy, int ship)
-{
-    float total = 0;
-    int grid_offset;
-    for (int y = miny; y < maxy; y++) {
-        for (int x = minx; x < maxx; x++) {
-            grid_offset = map_grid_offset(x, y);
-            int bridge_sprite = map_sprite_bridge_at(grid_offset);
-            if (bridge_sprite >= 1 + ship*6 && bridge_sprite <= 4 + ship*6) {
-                total += 0.5;
-            }
-        }
-    }
-    return (int)total;
-}
-
 static int min_x;
 static int min_y;
 
@@ -554,5 +538,56 @@ int building_count_gardens(int overgrown)
 int building_count_bridges(int ship)
 {
     get_min_map_xy();
-    return building_count_bridges_in_area(min_x, min_y, min_x + map_data.width, min_y + map_data.height, ship);
+    float total = 0;
+    int grid_offset;
+    for (int y = min_y; y < min_y + map_data.height; y++) {
+        for (int x = min_x; x < min_x + map_data.width; x++) {
+            grid_offset = map_grid_offset(x, y);
+            int bridge_sprite = map_sprite_bridge_at(grid_offset);
+            if (bridge_sprite >= 1 + ship*6 && bridge_sprite <= 4 + ship*6) {
+                total += 0.5;
+            }
+        }
+    }
+    return (int)total;
+}
+
+int building_count_bridges_in_area(int minx, int miny, int maxx, int maxy, int ship)
+{
+    array(int) bridge_ids;
+    array_init(bridge_ids, 4, NULL, NULL);
+    int grid_offset;
+    for (int y = miny; y < maxy; y++) {
+        for (int x = minx; x < maxx; x++) {
+            grid_offset = map_grid_offset(x, y);
+            int building_id = map_building_at(grid_offset);
+            if (!building_id) {
+                continue;
+            }
+            building *b = building_main(building_get(building_id));
+            if (!b) {
+                continue;
+            }
+            if ((b->type == (ship ? BUILDING_SHIP_BRIDGE : BUILDING_LOW_BRIDGE)) && map_is_bridge(grid_offset)) {
+                int found = 0;
+                int *item;
+                array_foreach(bridge_ids, item) {
+                    if (*item == b->id) {
+                        found = 1;
+                        break;
+                    }
+                }
+                if (!found) {
+                    int *bridge_id;
+                    array_new_item(bridge_ids, bridge_id);
+                    if (bridge_id) {
+                        *bridge_id = b->id;
+                    }
+                }
+            }
+        }
+    }
+    int total = bridge_ids.size;
+    array_clear(bridge_ids);
+    return total;
 }

--- a/src/building/count.c
+++ b/src/building/count.c
@@ -6,9 +6,11 @@
 #include "city/buildings.h"
 #include "city/health.h"
 #include "figure/figure.h"
+#include "map/bridge.h"
 #include "map/building.h"
 #include "map/data.h"
 #include "map/grid.h"
+#include "map/sprite.h"
 #include "map/terrain.h"
 #include "map/property.h"
 
@@ -500,6 +502,22 @@ int building_count_gardens_in_area(int minx, int miny, int maxx, int maxy, int o
     return total;
 }
 
+int building_count_bridges_in_area(int minx, int miny, int maxx, int maxy, int ship)
+{
+    float total = 0;
+    int grid_offset;
+    for (int y = miny; y < maxy; y++) {
+        for (int x = minx; x < maxx; x++) {
+            grid_offset = map_grid_offset(x, y);
+            int bridge_sprite = map_sprite_bridge_at(grid_offset);
+            if (bridge_sprite >= 1 + ship*6 && bridge_sprite <= 4 + ship*6) {
+                total += 0.5;
+            }
+        }
+    }
+    return (int)total;
+}
+
 static int min_x;
 static int min_y;
 
@@ -531,4 +549,10 @@ int building_count_gardens(int overgrown)
 {
     get_min_map_xy();
     return building_count_gardens_in_area(min_x, min_y, min_x + map_data.width, min_y + map_data.height, overgrown);
+}
+
+int building_count_bridges(int ship)
+{
+    get_min_map_xy();
+    return building_count_bridges_in_area(min_x, min_y, min_x + map_data.width, min_y + map_data.height, ship);
 }

--- a/src/building/count.h
+++ b/src/building/count.h
@@ -129,10 +129,11 @@ int building_count_roads(void);
 int building_count_highway(void);
 int building_count_plaza(void);
 int building_count_gardens(int overgrown);
+int building_count_bridges(int ship);
 int building_count_roads_in_area(int minx, int miny, int maxx, int maxy);
 int building_count_highway_in_area(int minx, int miny, int maxx, int maxy);
 int building_count_plaza_in_area(int minx, int miny, int maxx, int maxy);
 int building_count_gardens_in_area(int minx, int miny, int maxx, int maxy, int overgrown);
-
+int building_count_bridges_in_area(int minx, int miny, int maxx, int maxy, int ship);
 
 #endif // BUILDING_COUNT_H

--- a/src/building/properties.c
+++ b/src/building/properties.c
@@ -532,11 +532,13 @@ static building_properties properties[BUILDING_TYPE_MAX] = {
     },
     [BUILDING_LOW_BRIDGE] = {
         .size = 1,
-        .fire_proof = 1
+        .fire_proof = 1,
+        .event_data.attr = "low_bridge"
     },
     [BUILDING_SHIP_BRIDGE] = {
         .size = 1,
-        .fire_proof = 1
+        .fire_proof = 1,
+        .event_data.attr = "ship_bridge"
     },
     [BUILDING_SENATE] = {
         .size = 5,

--- a/src/scenario/event/condition_types.c
+++ b/src/scenario/event/condition_types.c
@@ -83,6 +83,12 @@ int scenario_condition_type_building_count_active_met(const scenario_condition_t
         case BUILDING_OVERGROWN_GARDENS:
             total_active_count = building_count_gardens(1);
             break;
+        case BUILDING_LOW_BRIDGE:
+            total_active_count = building_count_bridges(0);
+            break;
+        case BUILDING_SHIP_BRIDGE:
+            total_active_count = building_count_bridges(1);
+            break;
         default:
             total_active_count = building_count_active(type);
             break;
@@ -152,6 +158,12 @@ int scenario_condition_type_building_count_any_met(const scenario_condition_t *c
             break;
         case BUILDING_OVERGROWN_GARDENS:
             total_active_count = building_count_gardens(1);
+            break;
+        case BUILDING_LOW_BRIDGE:
+            total_active_count = building_count_bridges(0);
+            break;
+        case BUILDING_SHIP_BRIDGE:
+            total_active_count = building_count_bridges(1);
             break;
         default:
             total_active_count = building_count_total(type);
@@ -230,8 +242,14 @@ int scenario_condition_type_building_count_area_met(const scenario_condition_t *
         case BUILDING_OVERGROWN_GARDENS:
             buildings_in_area = building_count_gardens_in_area(minx, miny, maxx + 1, maxy + 1, 1);
             break;
+        case BUILDING_LOW_BRIDGE:
+            buildings_in_area = building_count_bridges_in_area(minx, miny, maxx + 1, maxy + 1, 0);
+            break;
+        case BUILDING_SHIP_BRIDGE:
+            buildings_in_area = building_count_bridges_in_area(minx, miny, maxx + 1, maxy + 1, 1);
+            break;
         default:
-            buildings_in_area = building_count_in_area(type, minx, miny, maxx + 1, maxy + 1);
+            buildings_in_area = building_count_in_area(type, minx, miny, maxx, maxy);
             break;
     }
 


### PR DESCRIPTION
Makes ship and low bridges countable.
But it crahes when loading into a mission with a bridge count in area condition scheduled.