### PR TITLE
Add other defined characters from font.c

### DIFF
--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -336,6 +336,10 @@ static int keyboard_character(uint8_t *text)
         add = 1;
     } else if (c == ',' || c == '.' || c == '?' || c == '!') {
         add = data.allow_punctuation;
+    } else if (c == '"' || c == '%' || c == '\'' || c == '(' || c == ')' ||
+               c == '*' || c == '+' || c == '/' || c == ':' || c == ';' ||
+               c == '=' || c == '_') { //other punctuation supported in current font files
+        add = data.allow_punctuation;
     } else if (c >= 0x80) { // do not check non-ascii for valid characters
         add = 1;
     }


### PR DESCRIPTION
According to `font.c` these are also supported and can be used in punctuation-enabled input boxes.
Adding as PR rather than commit since i don't have time to test the dependencies atm. 

Someone (probably me, just tomorrow), please check if it doesn't cross anything related to `fileio`, i.e. saving, loading, filtering, player name.
<img width="819" height="615" alt="image" src="https://github.com/user-attachments/assets/6d374d13-6f87-42ac-90e8-e0c8d88060f8" />
