### PR TITLE
Fix saving in pause menu causing saving CITY not scenario

### DIFF
--- a/src/widget/map_editor_pause_menu.c
+++ b/src/widget/map_editor_pause_menu.c
@@ -82,10 +82,10 @@ static void handle_input(const mouse *m, const hotkeys *h)
         window_go_back();
     }
     if (h->load_file) {
-        window_file_dialog_show(FILE_TYPE_SAVED_GAME, FILE_DIALOG_LOAD);
+        window_file_dialog_show(FILE_TYPE_SCENARIO, FILE_DIALOG_LOAD);
     }
     if (h->save_file) {
-        window_file_dialog_show(FILE_TYPE_SAVED_GAME, FILE_DIALOG_SAVE);
+        window_file_dialog_show(FILE_TYPE_SCENARIO, FILE_DIALOG_SAVE);
     }
 }
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/08ba77ec-eaa3-4e79-8e19-7645b7de0daf



Fix this bug. Pressing your hotkey to save in map_editor_pause_menu brings up the dialog for saving city and what happens when you save, you can see.