### PR TITLE
editor: text correction in 'Add/remove terrain event'

### DIFF
--- a/src/scenario/event/parameter_data.c
+++ b/src/scenario/event/parameter_data.c
@@ -1237,10 +1237,13 @@ void scenario_events_parameter_data_get_display_string_for_action(const scenario
             result_text = append_text(translation_for(TR_PARAMETER_RADIUS), result_text, &maxlength);
             result_text = translation_for_number_value(action->parameter2, result_text, &maxlength);
             if (action->parameter4) {
+                result_text = translation_for_type_lookup_by_value(PARAMETER_TYPE_TERRAIN, action->parameter3, result_text, &maxlength);
                 result_text = append_text(string_from_ascii(" "), result_text, &maxlength);
-                result_text = append_text(translation_for(TR_ACTION_TYPE_CHANGE_TERRAIN), result_text, &maxlength);
+                result_text = append_text(translation_for(TR_PARAMETER_ADD), result_text, &maxlength);
             } else {
                 result_text = translation_for_type_lookup_by_value(PARAMETER_TYPE_TERRAIN, action->parameter3, result_text, &maxlength);
+                result_text = append_text(string_from_ascii(" "), result_text, &maxlength);
+                result_text = append_text(translation_for(TR_EDITOR_DELETE), result_text, &maxlength);
             }
             return;
         }


### PR DESCRIPTION
before
![2025-09-07_212218](https://github.com/user-attachments/assets/a29d67c7-0068-4853-af66-9ab31acf888a)
![2025-09-07_212241](https://github.com/user-attachments/assets/b342e152-316a-44c8-93c7-8b1036a4bdb8)

after
![2025-09-07_212310](https://github.com/user-attachments/assets/f59370fc-b03d-4460-8283-1cee1f193b20)
![2025-09-07_212318](https://github.com/user-attachments/assets/de106935-bf50-4ede-a9db-290d2170be47)
