### PR TITLE
Move Yearly autosave to end of Dec, adjust Mars GT window height

### DIFF
--- a/src/game/tick.c
+++ b/src/game/tick.c
@@ -121,9 +121,6 @@ static void advance_month(void)
     if (setting_monthly_autosave()) {
         game_file_write_saved_game(dir_append_location("autosave.svx", PATH_LOCATION_SAVEGAME));
     }
-    if (new_year && config_get(CONFIG_GP_CH_YEARLY_AUTOSAVE)) {
-        game_file_make_yearly_autosave();
-    }
 
     city_weather_update(game_time_month());
 }
@@ -133,6 +130,7 @@ static void advance_day(void)
     if (game_time_advance_day()) {
         advance_month();
     }
+
     if (game_time_day() == 0 || game_time_day() == 8) {
         city_sentiment_update();
     }
@@ -140,6 +138,10 @@ static void advance_day(void)
         building_lighthouse_consume_timber();
     }
     tutorial_on_day_tick();
+    if (config_get(CONFIG_GP_CH_YEARLY_AUTOSAVE) && game_time_month() == 11 && game_time_day() == 15) {
+        // 0-based index so 11 = December, 15 = last day of the month
+        game_file_make_yearly_autosave();
+    }
 }
 
 static void advance_tick(void)

--- a/src/window/building_info.c
+++ b/src/window/building_info.c
@@ -553,7 +553,7 @@ static void init(int grid_offset)
         default: context.height_blocks = 22; break;
     }
     adjust_height_for_storage_buildings(&context);
-    if (screen_height() <= 600) {
+    if (screen_height() <= 800) { // longest window is mars grand temple at 736px height
         context.height_blocks = calc_bound(context.height_blocks, 0, 26);
     }
     // dialog placement


### PR DESCRIPTION
- Saves on last in-game day of December (display day isn't perfectly aligned - the game runs on 16 days system)
- Window heigh bounds calculation now triggers for resolutions under 800px height (from 600), since longest building_info windows are longer than 600. 