### PR TITLE
ship stalled anchoring

### DIFF
--- a/src/figuretype/trader.c
+++ b/src/figuretype/trader.c
@@ -813,7 +813,7 @@ void figure_trade_ship_action(figure *f)
             figure_movement_move_ticks_with_percentage(f, 1, move_speed);
             f->height_adjusted_ticks = 0;
             if (f->direction == DIR_FIGURE_AT_DESTINATION) {
-                f->wait_ticks = 0;
+                f->wait_ticks = TRADER_INITIAL_WAIT;    // prevent waiting 40 ticks on case FIGURE_ACTION_114_TRADE_SHIP_ANCHORED
                 f->action_state = FIGURE_ACTION_114_TRADE_SHIP_ANCHORED;
             } else if (f->direction == DIR_FIGURE_REROUTE) {
                 f->wait_ticks = 0;

--- a/src/figuretype/trader.c
+++ b/src/figuretype/trader.c
@@ -813,7 +813,7 @@ void figure_trade_ship_action(figure *f)
             figure_movement_move_ticks_with_percentage(f, 1, move_speed);
             f->height_adjusted_ticks = 0;
             if (f->direction == DIR_FIGURE_AT_DESTINATION) {
-                f->wait_ticks = TRADER_INITIAL_WAIT;    // prevent waiting 40 ticks on case FIGURE_ACTION_114_TRADE_SHIP_ANCHORED
+                f->wait_ticks = TRADER_INITIAL_WAIT;
                 f->action_state = FIGURE_ACTION_114_TRADE_SHIP_ANCHORED;
             } else if (f->direction == DIR_FIGURE_REROUTE) {
                 f->wait_ticks = 0;


### PR DESCRIPTION
Ships remain anchored for 40 ticks even when the dock is empty. I introduced this bug while fixing classic "Caesar3 locked docks" here: https://github.com/Keriew/augustus/pull/201

This fix triggers https://github.com/Keriew/augustus/blob/c4504a511fb222204ea1097a1d0f4b5491c043b4/src/figuretype/trader.c#L855
 on the very next tick, which immediately docks the ship if the dock is idle.