### PR TITLE
Fix house evolution info (latrines)

### DIFF
--- a/src/building/house_evolution.c
+++ b/src/building/house_evolution.c
@@ -624,17 +624,17 @@ void building_house_determine_evolve_text(building *house, int worst_desirabilit
     }
     // water
     int water = model->water;
-    if (water == 1 && !house->has_water_access) {
+    if (water == 1 && !house->has_water_access) { // House needs at least a well
         if (!house->has_well_access) {
             house->data.house.evolve_text_id = 1;
             return;
-        } else if (!house->has_latrines_access) {
+        } else if (!house->has_latrines_access && level == HOUSE_LARGE_SHACK) {
             house->data.house.evolve_text_id = 68;
             return;
         }
     }
 
-    if (water == 2 && !house->has_water_access) {
+    if (water == 2 && !house->has_water_access) { // House needs at least a well and latrines
         if (!house->has_latrines_access) {
             house->data.house.evolve_text_id = 67;
             return;


### PR DESCRIPTION
A tiny bug is making it so every house level with water == 1 demands latrine access, even though only the large shack actually needs it to evolve.

Unfortunately the game seems to ignore my change for some reason and displays the exact same message even if I change the text_id, help?

(maybe I'm just building it wrong somehow? but if it turns out to be something else that'd be useful to know)