### PR TITLE
Remove superfluous fire proofing

### DIFF
--- a/src/building/properties.c
+++ b/src/building/properties.c
@@ -1062,6 +1062,7 @@ static building_properties properties[BUILDING_TYPE_MAX] = {
     },
     [BUILDING_LOW_BRIDGE] = {
         .size = 1,
+        .fire_proof = 1,
         .event_data.attr = "low_bridge",
         .building_model_data = {.cost = 40, .desirability_value = 0, .desirability_step = 0,
             .desirability_step_size = 0, .desirability_range = 0, .laborers = 0}


### PR DESCRIPTION
I find it extremely silly that some of the most architectural complex buildings are magically immune to fire and collapse because they're expensive and require multiple stages to build. Forgetting to set up a prefect or engineer is a beginner mistake that all players have to learn to even begin playing this game. If anything I find it immersion breaking how these massive buildings somehow do not need any maintenance yet even a humble market is at risk of not just fire (understandable) but also collapse.

Buildings that should be able to burn and collapse:
- Hippodrome
- Colosseum
- Large Temples
- Grand Temples
- Oracle
- Architect Guild
- Lighthouse
- Caravanserai
- City Mint
- Warehouse: Convenient yes, but so arbitrary so I think they should not be made fireproof
- Low bridge: It is literally made out of wood, unless somehow the game will crash or something if it burns/collapses?

Building that shouldn't:
- Larariums: They're tiny and made out of stone
- Prefecture: I feel like it's just a bit frustrating for them to end up on fire or damaged, they shouldn't need an engineer post paired with them every time. Plus they're small enough I'd imagine an engineer wouldn't be able to fix much anyways (engineer posts themselves are fireproof already!)