### PR TITLE
Fix gatehouse displayed red when over walls

### DIFF
--- a/src/widget/city_building_ghost.c
+++ b/src/widget/city_building_ghost.c
@@ -520,8 +520,12 @@ static void draw_default(const map_tile *tile, int x_view, int y_view, building_
                 discouraged_terrain &= ~TERRAIN_ROAD;
             }
             if (type == BUILDING_GATEHOUSE) {
-                forbidden_terrain &= ~(TERRAIN_HIGHWAY | TERRAIN_WALL | TERRAIN_ROAD | TERRAIN_BUILDING);
-                discouraged_terrain &= ~(TERRAIN_HIGHWAY | TERRAIN_WALL | TERRAIN_ROAD | TERRAIN_BUILDING);
+                forbidden_terrain &= ~(TERRAIN_HIGHWAY | TERRAIN_WALL | TERRAIN_ROAD);
+                discouraged_terrain &= ~(TERRAIN_HIGHWAY | TERRAIN_WALL | TERRAIN_ROAD);
+                if (map_terrain_is(tile_offset, TERRAIN_WALL)) {
+                    forbidden_terrain &= ~TERRAIN_BUILDING;
+                    discouraged_terrain &= ~TERRAIN_BUILDING;
+                }
             }
             if (type == BUILDING_TOWER) {
                 forbidden_terrain &= ~TERRAIN_WALL & ~TERRAIN_BUILDING;


### PR DESCRIPTION
Walls recently got buildings so gatehouses were now displayed in the wrong color when over walls.
Blame Peshirex.