### PR TITLE
Fix bugs with building reservoirs

### DIFF
--- a/src/building/construction_building.c
+++ b/src/building/construction_building.c
@@ -427,6 +427,8 @@ int building_construction_fill_vacant_lots(grid_slice *area)
 
 int building_construction_place_building(building_type type, int x, int y, int exact_coordinates)
 {
+    int grid_offset = map_grid_offset(x, y);
+    
     int terrain_mask = TERRAIN_ALL;
     if (building_type_is_roadblock(type)) {
         terrain_mask = type == BUILDING_GATEHOUSE ? ~TERRAIN_WALL & ~TERRAIN_ROAD &
@@ -455,7 +457,7 @@ int building_construction_place_building(building_type type, int x, int y, int e
     int building_orientation = 0;
     if (type == BUILDING_GATEHOUSE || type == BUILDING_WAREHOUSE) {
         //check if there's a preset orientation from old building
-        building *old_b = building_main(building_get(map_building_rubble_building_id(map_grid_offset(x, y))));
+        building *old_b = building_main(building_get(map_building_rubble_building_id(grid_offset)));
         if (old_b && (old_b->type == BUILDING_GATEHOUSE ||
             old_b->type == BUILDING_WAREHOUSE || old_b->type == BUILDING_WAREHOUSE_SPACE)) {
             building_orientation = old_b->subtype.orientation;
@@ -492,7 +494,7 @@ int building_construction_place_building(building_type type, int x, int y, int e
             city_warning_show(WARNING_CLEAR_LAND_NEEDED, NEW_WARNING_SLOT);
             return 0;
         }
-        if (!check_gatehouse_tiles(map_grid_offset(x, y))) { //helper to make sure all building tiles are on walls
+        if (!check_gatehouse_tiles(grid_offset)) { //helper to make sure all building tiles are on walls
             city_warning_show(WARNING_CLEAR_LAND_NEEDED, NEW_WARNING_SLOT);
             return 0;
         }

--- a/src/map/routing.c
+++ b/src/map/routing.c
@@ -447,6 +447,18 @@ static int map_can_place_initial_road_or_aqueduct(int grid_offset, int is_aquedu
     }
 }
 
+static int aqueduct_in_reservoir(int center_offset) {
+    for (int y = map_grid_offset_to_y(center_offset) - 1; y < map_grid_offset_to_y(center_offset) + 2; y++) {
+        for (int x = map_grid_offset_to_x(center_offset) - 1; x < map_grid_offset_to_x(center_offset) + 2; x++) {
+            if (map_terrain_is(map_grid_offset(x, y), TERRAIN_AQUEDUCT)) {
+                return 1;
+            }
+        }
+    }
+    
+    return 0;
+}
+
 int map_routing_calculate_distances_for_building(routed_building_type type, int x, int y)
 {
     int source_offset = map_grid_offset(x, y);
@@ -464,8 +476,15 @@ int map_routing_calculate_distances_for_building(routed_building_type type, int 
         route_queue_all_from(source_offset, DIRECTIONS_NO_DIAGONALS, callback_calc_distance_build_highway, 0);
         return 1;
     }
+    
+    if (type == ROUTED_BUILDING_DRAGGABLE_RESERVOIR) {
+        if (!map_terrain_is(source_offset, TERRAIN_AQUEDUCT) && aqueduct_in_reservoir(source_offset)) {
+            return 0;
+        }
+    }
 
-    if (!map_can_place_initial_road_or_aqueduct(source_offset, type != ROUTED_BUILDING_ROAD)) {
+    if (!map_can_place_initial_road_or_aqueduct(source_offset, type != ROUTED_BUILDING_ROAD &&
+        type != ROUTED_BUILDING_DRAGGABLE_RESERVOIR)) {
         return 0;
     }
     if (map_terrain_is(source_offset, TERRAIN_ROAD) &&


### PR DESCRIPTION
Reservoirs weren't buildable anymore when the middle tile was on an Aqueduct though were buildable when a corner was over an aqueduct but it was highlighted red in that case.
Those things are fixed in this PR.