### PR TITLE
Fix mothballed supply posts not processing food

### DIFF
--- a/src/building/building.c
+++ b/src/building/building.c
@@ -117,6 +117,16 @@ int building_find(building_type type)
     return 0;
 }
 
+int building_find_with_mothballed(building_type type)
+{
+    for (building *b = data.first_of_type[type]; b; b = b->next_of_type) {
+        if (b->state == BUILDING_STATE_IN_USE || b->state == BUILDING_STATE_MOTHBALLED) {
+            return b->id;
+        }
+    }
+    return 0;
+}
+
 building *building_first_of_type(building_type type)
 {
     return data.first_of_type[type];

--- a/src/building/building.h
+++ b/src/building/building.h
@@ -216,6 +216,8 @@ int building_count(void);
 
 int building_find(building_type type);
 
+int building_find_with_mothballed(building_type type);
+
 int building_can_repair_type(building_type type);
 
 building *building_first_of_type(building_type type);

--- a/src/city/resource.c
+++ b/src/city/resource.c
@@ -543,7 +543,7 @@ static int house_consume_food(void)
 static int mess_hall_consume_food(void)
 {
     int total_consumed = 0;
-    building *b = building_get(building_find(BUILDING_MESS_HALL));
+    building *b = building_get(building_find_with_mothballed(BUILDING_MESS_HALL));
     if (!b || (b->state != BUILDING_STATE_IN_USE && b->state != BUILDING_STATE_MOTHBALLED)) {
         return 0;
     }


### PR DESCRIPTION
Adds a function building_find_with_mothballed which does the same as building_find but also finding mothballed buildings. This function is currently only used to fix the bug.