### PR TITLE
Fix tooltip desynchronization when scrolling variable list

### DIFF
--- a/src/window/editor/custom_variables.c
+++ b/src/window/editor/custom_variables.c
@@ -775,31 +775,45 @@ static void get_tooltip(tooltip_context *c)
         return;
     }
 
-    if (variable_buttons.focused_item.is_focused) {
-        unsigned int id = data.custom_variable_ids[variable_buttons.focused_item.position];
-        if (dropdown_button_handle_tooltip(&color_dropdowns[id - 1], c)) {
+    if (!variable_buttons.focused_item.is_focused) {
+        return;
+    }
+
+    unsigned int index = variable_buttons.focused_item.index;
+    unsigned int pos = variable_buttons.focused_item.position;
+
+    if (index >= data.custom_variables_in_use) {
+        return;
+    }
+
+    unsigned int id = data.custom_variable_ids[index];
+
+    // Color dropdowns
+    if (pos < MAX_VISIBLE_GRID_ITEMS) {
+        if (dropdown_button_handle_tooltip(&color_dropdowns[pos], c)) {
             return;
         }
-        // Name
-        if (data.item_buttons_focus_id == 2) {
-            const uint8_t *name = scenario_custom_variable_get_name(id);
-            int name_w = item_buttons[1].width;
-            if (name && *name && text_get_width(name, FONT_SMALL_PLAIN) > name_w - 16) {
-                c->precomposed_text = name;
-                c->type = TOOLTIP_BUTTON;
-                return;
-            }
-        }
+    }
 
-        // Display Text
-        if (data.item_buttons_focus_id == 4) {
-            const uint8_t *display_text = scenario_custom_variable_get_text_display(id);
-            int display_w = item_buttons[3].width;
-            if (display_text && *display_text && text_get_width(display_text, FONT_SMALL_PLAIN) > display_w - 16) {
-                c->precomposed_text = display_text;
-                c->type = TOOLTIP_BUTTON;
-                return;
-            }
+    // Name
+    if (data.item_buttons_focus_id == 2) {
+        const uint8_t *name = scenario_custom_variable_get_name(id);
+        int name_w = item_buttons[1].width;
+        if (name && *name && text_get_width(name, FONT_SMALL_PLAIN) > name_w - 16) {
+            c->precomposed_text = name;
+            c->type = TOOLTIP_BUTTON;
+            return;
+        }
+    }
+
+    // Display Text
+    if (data.item_buttons_focus_id == 4) {
+        const uint8_t *display_text = scenario_custom_variable_get_text_display(id);
+        int display_w = item_buttons[3].width;
+        if (display_text && *display_text && text_get_width(display_text, FONT_SMALL_PLAIN) > display_w - 16) {
+            c->precomposed_text = display_text;
+            c->type = TOOLTIP_BUTTON;
+            return;
         }
     }
 }


### PR DESCRIPTION
Fixes an issue where tooltips were bound to visible row positions instead of actual variable indices.
When the list was scrolled, tooltips could display information for the wrong variable.
ex. 
![2026-01-25_203451](https://github.com/user-attachments/assets/33bc8c09-e93b-49bc-abd1-be8252eeb45a)
![2026-01-25_203505](https://github.com/user-attachments/assets/f5c3d951-1b52-440e-acf7-b35966bd6a13)
