### PR TITLE
README: fix dead link to full-size screenshot image

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Because of gameplay changes and additions, save files from Augustus are NOT comp
 
 Augustus, like Julius, requires the original assets (graphics, sounds, etc) from Caesar 3 to run. Augustus optionally [supports the high-quality MP3 files](https://github.com/bvschaik/julius/wiki/MP3-Support) once provided on the Sierra website.
 
-![](doc/main-image.png)
+[![](doc/main-image.png)](https://github.com/user-attachments/assets/5027579d-4277-4b1f-9eca-297a04cb1c79)
 
 ## Running the game
 


### PR DESCRIPTION
I got it under 10 MB using this command:

```
cwebp -q 85 -alpha_q 90 -m 6 -af fefa2d.png -o fefa2d-85.webp
```

![fefa2d-85](https://github.com/user-attachments/assets/5027579d-4277-4b1f-9eca-297a04cb1c79)
