### PR TITLE
Fix: screenshot crush when using non-ascii file path

### DIFF
--- a/src/graphics/screenshot.c
+++ b/src/graphics/screenshot.c
@@ -221,7 +221,7 @@ static void show_saved_notice(const char *filename)
     const uint8_t *prefix = translation_for(TR_WARNING_SCREENSHOT_SAVED);
     string_copy(prefix, notice_text, FILE_NAME_MAX);
     int prefix_length = string_length(prefix);
-    string_copy(string_from_ascii(filename), &notice_text[prefix_length], FILE_NAME_MAX - prefix_length);
+    encoding_from_utf8(filename, &notice_text[prefix_length], FILE_NAME_MAX - prefix_length);
 
     city_warning_show_custom(notice_text, 0);
 }


### PR DESCRIPTION
When saving screenshot will cause the game to crash. The cause of the problem is the file path contains non-ASCII characters. Just make a NULL judgment before the pop-up window will avoid this crush.