### PR TITLE
Placeholder PR for funds being displayed in the empire map

### DIFF
--- a/src/window/empire.c
+++ b/src/window/empire.c
@@ -2038,7 +2038,6 @@ static void handle_input(const mouse *m, const hotkeys *h)
 
             switch (obj->type) {
                 case EMPIRE_OBJECT_CITY:
-
                     empire_clear_selected_object();
                     window_invalidate();
                     break;


### PR DESCRIPTION
This PR is now a placeholder for the fund display to be not in that corner (cause I think thats kinda hideous) but in the top bar if that's possible with label drawing.