### PR TITLE
FIX: (#1669) Fix handling emptying granaries and warehouses in request dispatch

### DIFF
--- a/src/building/granary.c
+++ b/src/building/granary.c
@@ -204,7 +204,9 @@ int building_granary_count_available_resource(building *b, int resource, int res
     if (b->type != BUILDING_GRANARY || b->state != BUILDING_STATE_IN_USE) {
         return 0;
     }
-    if (!respect_maintaining || (building_storage_get_state(b, resource, 1) < BUILDING_STORAGE_STATE_MAINTAINING)) {
+    if (!respect_maintaining ||
+        building_storage_get_state(b, resource, 1) < BUILDING_STORAGE_STATE_MAINTAINING ||
+        building_storage_get_empty_all(b->id)) {
         return building_granary_get_amount(b, resource);
     } else {
         return 0;
@@ -239,10 +241,11 @@ static void try_create_cart_to_rome(building *b, int resource, int loads)
 
 int building_granaries_send_resources_to_rome(int resource, int amount)
 {
-    // first go for non-getting, non-maintaining granaries with caesar permission
+    // first go for emptying or non-getting, non-maintaining granaries with caesar permission
     for (building *b = building_first_of_type(BUILDING_GRANARY); b && amount; b = b->next_of_type) {
         if (b->state == BUILDING_STATE_IN_USE) {
-            if (building_storage_get_state(b, resource, 1) < BUILDING_STORAGE_STATE_GETTING &&
+            if ((building_storage_get_empty_all(b->id) ||
+                 building_storage_get_state(b, resource, 1) < BUILDING_STORAGE_STATE_GETTING) &&
                 building_storage_get_permission(BUILDING_STORAGE_PERMISSION_CAESAR, b)) {
                 int taken_loads = building_granary_try_remove_resource(b, resource, amount);
                 amount -= taken_loads;

--- a/src/building/warehouse.c
+++ b/src/building/warehouse.c
@@ -504,7 +504,7 @@ int building_warehouses_count_available_resource(int resource, int respect_maint
             continue;
         }
         if (!respect_maintaining ||
-            building_storage_get_state(b, resource, 1) != BUILDING_STORAGE_STATE_MAINTAINING ||
+            building_storage_get_state(b, resource, 1) < BUILDING_STORAGE_STATE_MAINTAINING ||
             building_storage_get_empty_all(b->id)) {
             total += building_warehouse_get_amount(b, resource);
         }
@@ -526,10 +526,11 @@ static void try_create_cart_to_rome(building *b, int resource, int loads)
 
 int building_warehouses_send_resources_to_rome(int resource, int amount)
 {
-    // first go for non-getting, non-maintaining warehouses with caesar permission
+    // first go for emptying or non-getting, non-maintaining warehouses with caesar permission
     for (building *b = building_first_of_type(BUILDING_WAREHOUSE); b && amount; b = b->next_of_type) {
         if (b->state == BUILDING_STATE_IN_USE) {
-            if (building_storage_get_state(b, resource, 1) < BUILDING_STORAGE_STATE_GETTING &&
+            if ((building_storage_get_empty_all(b->id) ||
+                 building_storage_get_state(b, resource, 1) < BUILDING_STORAGE_STATE_GETTING) &&
                 building_storage_get_permission(BUILDING_STORAGE_PERMISSION_CAESAR, b)) {
                 int taken_loads = building_warehouse_try_remove_resource(b, resource, amount);
                 amount -= taken_loads;


### PR DESCRIPTION
FIX: #1669

Emptying warehouses contribute to total available amount of resource in `city_resource_get_amount_for_request()` through `building_warehouses_count_available_resource()` but were not handled when removing resource in `building_warehouses_send_resources_to_rome()` while dispatch.

Fixed by including emptying warehouses among the first warehouses considered to remove the resource.

Emptying granaries have been updated with the same logic.