### PR TITLE
epithets.c: fix rich text line height for Asian languages

### DIFF
--- a/src/core/locale.c
+++ b/src/core/locale.c
@@ -122,7 +122,6 @@ language_type locale_last_determined_language(void)
     }
 }
 
-
 int locale_year_before_ad(void)
 {
     // In all languages it's "200 AD" except for English
@@ -166,3 +165,12 @@ int locale_translate_rank_autosaves(void)
     }
 }
 
+int locale_is_asian(void)
+{
+    language_type lang = locale_last_determined_language();
+
+    return lang == LANGUAGE_SIMPLIFIED_CHINESE ||
+        lang == LANGUAGE_TRADITIONAL_CHINESE ||
+        lang == LANGUAGE_JAPANESE ||
+        lang == LANGUAGE_KOREAN;
+}

--- a/src/core/locale.h
+++ b/src/core/locale.h
@@ -66,4 +66,6 @@ int locale_paragraph_indent(void);
  */
 int locale_translate_rank_autosaves(void);
 
+int locale_is_asian(void);
+
 #endif // CORE_LOCALE_H

--- a/src/window/epithets.c
+++ b/src/window/epithets.c
@@ -53,15 +53,6 @@ static option_menu_item epithets_options[18] = {
 
 static int selected_god_id;
 
-static int locale_is_asian(void)
-{
-    language_type lang = locale_last_determined_language();
-    return lang == LANGUAGE_SIMPLIFIED_CHINESE ||
-        lang == LANGUAGE_TRADITIONAL_CHINESE ||
-        lang == LANGUAGE_JAPANESE ||
-        lang == LANGUAGE_KOREAN;
-}
-
 static image_button image_buttons_bottom[] = {
     {598, 395, 24, 24, IB_NORMAL, GROUP_CONTEXT_ICONS, 4, button_close, button_none, 0, 0, 1}
 };

--- a/src/window/epithets.c
+++ b/src/window/epithets.c
@@ -53,7 +53,7 @@ static option_menu_item epithets_options[18] = {
 
 static int selected_god_id;
 
-static int locale_is_cjk(void)
+static int locale_is_asian(void)
 {
     language_type lang = locale_last_determined_language();
     return lang == LANGUAGE_SIMPLIFIED_CHINESE ||
@@ -177,7 +177,7 @@ static void draw_background(void)
     inner_panel_draw(16, 165, 35, 14);
     rich_text_init(epithet_text_buffer, 24, 165, 35, 14, 0);
 
-    if (locale_is_cjk()) {
+    if (locale_is_asian()) {
         rich_text_draw(epithet_text_buffer, 32, 180, 35 * BLOCK_SIZE, 10, 0);
     } else {
         rich_text_draw(epithet_text_buffer, 32, 180, 35 * BLOCK_SIZE, 12, 0);

--- a/src/window/epithets.c
+++ b/src/window/epithets.c
@@ -53,6 +53,15 @@ static option_menu_item epithets_options[18] = {
 
 static int selected_god_id;
 
+static int locale_is_cjk(void)
+{
+    language_type lang = locale_last_determined_language();
+    return lang == LANGUAGE_SIMPLIFIED_CHINESE ||
+        lang == LANGUAGE_TRADITIONAL_CHINESE ||
+        lang == LANGUAGE_JAPANESE ||
+        lang == LANGUAGE_KOREAN;
+}
+
 static image_button image_buttons_bottom[] = {
     {598, 395, 24, 24, IB_NORMAL, GROUP_CONTEXT_ICONS, 4, button_close, button_none, 0, 0, 1}
 };
@@ -63,8 +72,7 @@ static generic_button buttons_gods_size[] = {
     {230, 56, 80, 90, button_god},
     {330, 56, 80, 90, button_god},
     {430, 56, 80, 90, button_god},
-    {530, 56, 80, 90, button_god},
-    {630, 56, 80, 90, button_god}
+    {530, 56, 80, 90, button_god}
 };
 
 static unsigned int focus_button_id;
@@ -135,14 +143,14 @@ static void draw_background(void)
     graphics_in_dialog();
 
     outer_panel_draw(0, 0, 40, 27);
-    
+
     lang_text_draw_centered(CUSTOM_TRANSLATION, TR_WINDOW_ADVISOR_EPITHETS, 0, 15, 640, FONT_LARGE_BLACK);
     int border_image_id = assets_get_image_id("UI", "Image Border Small");
     int highlight_image_id = assets_get_image_id("UI", "Highlight");
     int base_image_id = assets_get_image_id("UI", "Pantheon_Epithet_Button_01");
     color_t border_color =  COLOR_BORDER_ORANGE;
     color_t highlight_color = COLOR_MASK_NONE;
-    
+
     for (int god = 0; god <= MAX_GODS; god++) {
         if (god == selected_god_id) {
             button_border_draw(100 * god + 25, 51, 91, 101, 1);
@@ -168,7 +176,12 @@ static void draw_background(void)
 
     inner_panel_draw(16, 165, 35, 14);
     rich_text_init(epithet_text_buffer, 24, 165, 35, 14, 0);
-    rich_text_draw(epithet_text_buffer, 32, 180, 35 * BLOCK_SIZE, 12, 0);
+
+    if (locale_is_cjk()) {
+        rich_text_draw(epithet_text_buffer, 32, 180, 35 * BLOCK_SIZE, 10, 0);
+    } else {
+        rich_text_draw(epithet_text_buffer, 32, 180, 35 * BLOCK_SIZE, 12, 0);
+    }
 
     lang_text_draw_centered(13, 1, 10, 410, 585, FONT_SMALL_PLAIN); //Right-click to Exit
 

--- a/src/window/epithets.c
+++ b/src/window/epithets.c
@@ -168,11 +168,8 @@ static void draw_background(void)
     inner_panel_draw(16, 165, 35, 14);
     rich_text_init(epithet_text_buffer, 24, 165, 35, 14, 0);
 
-    if (locale_is_asian()) {
-        rich_text_draw(epithet_text_buffer, 32, 180, 35 * BLOCK_SIZE, 10, 0);
-    } else {
-        rich_text_draw(epithet_text_buffer, 32, 180, 35 * BLOCK_SIZE, 12, 0);
-    }
+    int lines = locale_is_asian() ? 10 : 12;
+    rich_text_draw(epithet_text_buffer, 32, 180, 35 * BLOCK_SIZE, lines, 0);
 
     lang_text_draw_centered(13, 1, 10, 410, 585, FONT_SMALL_PLAIN); //Right-click to Exit
 


### PR DESCRIPTION
https://discord.com/channels/136544899339124736/1502140522792353883

- epithets.c: fix rich text line height for Asian languages

<details>

<img width="680" height="528" alt="2026-05-08_125741" src="https://github.com/user-attachments/assets/7da90f04-9d18-4062-8922-5cffeb3231aa" />

<br>

<img width="671" height="536" alt="2026-05-08_125801" src="https://github.com/user-attachments/assets/ca8253ab-26f4-4a46-a77b-e2c968fc3a8b" />


</details> 




- Remove extra button that caused crash on click
<details>

<img width="768" height="525" alt="2026-05-08_123306s" src="https://github.com/user-attachments/assets/fd10ef4f-5a6d-4418-a7d7-c3257771bb52" />

</details> 


