### PR TITLE
Text drawing API updates: floats and lang_fragments

### DIFF
--- a/src/core/string.c
+++ b/src/core/string.c
@@ -4,7 +4,6 @@
 
 #include <ctype.h>
 #include <stddef.h>
-#include "string.h"
 
 int string_equals(const uint8_t *a, const uint8_t *b)
 {

--- a/src/core/string.c
+++ b/src/core/string.c
@@ -4,6 +4,7 @@
 
 #include <ctype.h>
 #include <stddef.h>
+#include "string.h"
 
 int string_equals(const uint8_t *a, const uint8_t *b)
 {
@@ -60,7 +61,7 @@ int string_length(const uint8_t *str)
     if (!str) {
         return 0;
     }
-    
+
     int length = 0;
     while (*str) {
         length++;
@@ -140,6 +141,50 @@ int string_from_int(uint8_t *dst, int value, int force_plus_sign)
 
     dst[total_chars] = 0;
 
+    return total_chars;
+}
+
+int string_from_float(uint8_t *dst, float value, int decimal_places, int force_plus_sign)
+{
+    int total_chars = 0;
+
+    if (decimal_places < 0) {
+        decimal_places = 0;
+    } else if (decimal_places > 5) {
+        decimal_places = 5; // why would we ever need more than 5 decimal places? This ain't nuclear physics
+    }
+
+    if (value < 0.0f) {
+        dst[total_chars++] = '-';
+        value = -value;
+    } else if (force_plus_sign) {
+        dst[total_chars++] = '+';
+    }
+
+    int scale = 1;
+    for (int i = 0; i < decimal_places; i++) {
+        scale *= 10;
+    }
+
+    // Round once at full precision so carry into whole part is handled.
+    int64_t scaled = (int64_t) (value * (float) scale + 0.5f);
+    int int_part = (int) (scaled / scale);
+    int fractional_digits = (int) (scaled % scale);
+
+    total_chars += string_from_int(&dst[total_chars], int_part, 0);
+
+    if (decimal_places > 0) {
+        dst[total_chars++] = '.';
+
+        // Emit exactly decimal_places digits, including leading zeros.
+        int divisor = scale / 10;
+        while (divisor > 0) {
+            dst[total_chars++] = (uint8_t) ('0' + ((fractional_digits / divisor) % 10));
+            divisor /= 10;
+        }
+    }
+
+    dst[total_chars] = 0;
     return total_chars;
 }
 

--- a/src/core/string.h
+++ b/src/core/string.h
@@ -66,6 +66,16 @@ int string_to_int(const uint8_t *str);
 int string_from_int(uint8_t *dst, int value, int force_plus_sign);
 
 /**
+ * Converts float to string
+ * @param dst Output string
+ * @param value Value to write
+ * @param decimal_places Number of decimal places to write, from 0 to 5
+ * @param force_plus_sign Force plus sign in front of positive value
+ * @return Total number of characters written to dst
+ */
+int string_from_float(uint8_t *dst, float value, int decimal_places, int force_plus_sign);
+
+/**
  * Compares two strings similar to how strcmp does.
  * Compares the lowercase of the two strings, so uppercase is treated equal to lowercase.
  * @param a String A

--- a/src/graphics/lang_text.c
+++ b/src/graphics/lang_text.c
@@ -5,6 +5,47 @@
 #include "core/string.h"
 #include "graphics/text.h"
 
+
+void lang_text_fragment_label(lang_fragment *f, int text_group, int text_id)
+{
+    f->type = LANG_FRAG_LABEL;
+    f->text_group = text_group;
+    f->text_id = text_id;
+}
+
+void lang_text_fragment_amount(lang_fragment *f, int text_group, int text_id, int number)
+{
+    f->type = LANG_FRAG_AMOUNT;
+    f->text_group = text_group;
+    f->text_id = text_id;
+    f->number = number;
+}
+
+void lang_text_fragment_number(lang_fragment *f, int number)
+{
+    f->type = LANG_FRAG_NUMBER;
+    f->number = number;
+}
+
+void lang_text_fragment_float(lang_fragment *f, float number, int decimal_places)
+{
+    f->type = LANG_FRAG_FLOAT;
+    f->float_number = number;
+    f->decimal_places = decimal_places;
+}
+
+void lang_text_fragment_text(lang_fragment *f, const uint8_t *text)
+{
+    f->type = LANG_FRAG_TEXT;
+    f->text = text;
+}
+
+void lang_text_fragment_space(lang_fragment *f, int space_width)
+{
+    f->type = LANG_FRAG_SPACE;
+    f->space_width = space_width;
+}
+
 int lang_text_get_width(int group, int number, font_t font)
 {
     const uint8_t *str = lang_get_string(group, number);
@@ -185,6 +226,9 @@ int lang_text_get_sequence_width(const lang_fragment *seq, int count, font_t fon
             case LANG_FRAG_SPACE:
                 width += f->space_width;
                 break;
+            case LANG_FRAG_FLOAT:
+                width += text_get_number_float_width(f->float_number, f->decimal_places, '\0', "", font);
+                break;
         }
     }
     return width;
@@ -210,6 +254,9 @@ int lang_text_draw_sequence(const lang_fragment *seq, int count, int x, int y, f
                 break;
             case LANG_FRAG_SPACE:
                 width += f->space_width;
+                break;
+            case LANG_FRAG_FLOAT:
+                width += text_draw_number_float(f->float_number, 2, '\0', "", x + width, y, font, color);
                 break;
         }
     }
@@ -244,6 +291,9 @@ int lang_text_draw_sequence_multiline(const lang_fragment *seq, int count, int x
                 break;
             case LANG_FRAG_SPACE:
                 fragment_width = f->space_width;
+                break;
+            case LANG_FRAG_FLOAT:
+                fragment_width = text_get_number_float_width(f->float_number, f->decimal_places, '\0', "", font);
                 break;
         }
 
@@ -287,6 +337,10 @@ int lang_text_draw_sequence_multiline(const lang_fragment *seq, int count, int x
                         case LANG_FRAG_SPACE:
                             current_x += f->space_width;
                             break;
+                        case LANG_FRAG_FLOAT:
+                            current_x += text_draw_number_float(f->float_number, f->decimal_places, '\0', "",
+                                current_x, current_y, font, color);
+                            break;
                         default:
                             break;
                     }
@@ -310,6 +364,10 @@ int lang_text_draw_sequence_multiline(const lang_fragment *seq, int count, int x
                     break;
                 case LANG_FRAG_SPACE:
                     current_x += f->space_width;
+                    break;
+                case LANG_FRAG_FLOAT:
+                    current_x += text_draw_number_float(f->float_number, f->decimal_places, '\0', "",
+                        current_x, current_y, font, color);
                     break;
             }
         }
@@ -360,6 +418,9 @@ static int lang_text_draw_sequence_ellipsized_internal(const lang_fragment *seq,
             case LANG_FRAG_SPACE:
                 fragment_width = f->space_width;
                 break;
+            case LANG_FRAG_FLOAT:
+                fragment_width = text_get_number_float_width(f->float_number, f->decimal_places, '\0', "", font);
+                break;
         }
 
         // Check if this fragment fits in the remaining width
@@ -382,6 +443,10 @@ static int lang_text_draw_sequence_ellipsized_internal(const lang_fragment *seq,
                 case LANG_FRAG_SPACE:
                     width += f->space_width;
                     break;
+                case LANG_FRAG_FLOAT:
+                    width += text_draw_number_float(f->float_number, f->decimal_places, '\0', "",
+                        x + width, y, font, color);
+                    break;
             }
             remaining_width -= fragment_width;
         } else {
@@ -402,8 +467,9 @@ static int lang_text_draw_sequence_ellipsized_internal(const lang_fragment *seq,
                 case LANG_FRAG_AMOUNT:
                 case LANG_FRAG_NUMBER:
                 case LANG_FRAG_SPACE:
+                case LANG_FRAG_FLOAT:
                     // For non-text fragments, just draw them (they'll overflow or be cut off)
-                    // Numbers/amounts don't ellipsize well, so we just skip them if they don't fit
+                    // Numbers/amounts/floats don't ellipsize well, so we just skip them if they don't fit
                     break;
             }
 
@@ -525,6 +591,14 @@ int lang_text_concatenate_sequence(const lang_fragment *seq, int count, uint8_t 
                     cursor++;
                     remaining--;
                 }
+                break;
+
+            case LANG_FRAG_FLOAT:
+                len = string_from_float(number_buffer, f->float_number, f->decimal_places, 0);
+                if (len > remaining) len = remaining;
+                string_copy(number_buffer, cursor, len + 1);
+                cursor += len;
+                remaining -= len;
                 break;
         }
     }

--- a/src/graphics/lang_text.h
+++ b/src/graphics/lang_text.h
@@ -5,22 +5,50 @@
 #include "graphics/color.h"
 #include "translation/translation.h"
 
+/** Discriminator tag for @ref lang_fragment. */
 typedef enum {
-    LANG_FRAG_LABEL,    // a lang string
-    LANG_FRAG_AMOUNT,   // a number + associated lang string
-    LANG_FRAG_NUMBER,   // raw number
-    LANG_FRAG_TEXT,     // raw utf-8 string
-    LANG_FRAG_SPACE,    // a space of given width
+    LANG_FRAG_LABEL,    ///< A lang string identified by group + id.
+    LANG_FRAG_AMOUNT,   ///< A number with an associated singular/plural lang string.
+    LANG_FRAG_NUMBER,   ///< A raw integer.
+    LANG_FRAG_FLOAT,    ///< A raw float with a configurable number of decimal places.
+    LANG_FRAG_TEXT,     ///< A raw UTF-8 string pointer.
+    LANG_FRAG_SPACE,    ///< A blank gap of explicit pixel width.
 } lang_fragment_type;
 
+/**
+ * A single renderable unit in a fragment sequence.
+ * Caller owns the memory; use the constructor helpers below to fill fields.
+ * Only the fields relevant to the fragment's @ref type are read.
+ */
 typedef struct {
     lang_fragment_type type;
-    int text_group;
-    int text_id;
-    int number;
-    int space_width;
-    const uint8_t *text;
+    int text_group;         ///< Lang string group  (@ref LANG_FRAG_LABEL, @ref LANG_FRAG_AMOUNT).
+    int text_id;            ///< Lang string id     (@ref LANG_FRAG_LABEL, @ref LANG_FRAG_AMOUNT).
+    int number;             ///< Integer value      (@ref LANG_FRAG_NUMBER, @ref LANG_FRAG_AMOUNT).
+    float float_number;     ///< Float value        (@ref LANG_FRAG_FLOAT).
+    int decimal_places;     ///< Decimal precision  (@ref LANG_FRAG_FLOAT).
+    int space_width;        ///< Gap in pixels      (@ref LANG_FRAG_SPACE).
+    const uint8_t *text;    ///< UTF-8 string       (@ref LANG_FRAG_TEXT).
 } lang_fragment;
+
+/**
+ * @name Fragment constructors
+ * Convenience helpers that populate a caller-owned @ref lang_fragment.
+ * @{
+ */
+/** Initialises @p f as a lang string label (group + id). */
+void lang_text_fragment_label(lang_fragment *f, int text_group, int text_id);
+/** Initialises @p f as a number with a singular/plural lang string (group + id + number). */
+void lang_text_fragment_amount(lang_fragment *f, int text_group, int text_id, int number);
+/** Initialises @p f as a raw integer. */
+void lang_text_fragment_number(lang_fragment *f, int number);
+/** Initialises @p f as a float rendered to @p decimal_places places. */
+void lang_text_fragment_float(lang_fragment *f, float number, int decimal_places);
+/** Initialises @p f as a raw UTF-8 string pointer. */
+void lang_text_fragment_text(lang_fragment *f, const uint8_t *text);
+/** Initialises @p f as a blank gap of @p space_width pixels. */
+void lang_text_fragment_space(lang_fragment *f, int space_width);
+/** @} */
 
 int lang_text_get_width(int group, int number, font_t font);
 
@@ -46,15 +74,40 @@ void lang_text_draw_month_year_max_width(
 
 int lang_text_draw_multiline(int group, int number, int x_offset, int y_offset, int box_width, font_t font);
 
+/**
+ * @name Fragment sequence API
+ * Functions that operate on an array of @ref lang_fragment (a "sequence").
+ * @{
+ */
+/** Returns the total pixel width of the sequence (no trailing space). */
 int lang_text_get_sequence_width(const lang_fragment *seq, int count, font_t font);
+/** Draws the sequence left-aligned at (@p x, @p y). Returns the width drawn. */
 int lang_text_draw_sequence(const lang_fragment *seq, int count, int x, int y, font_t font, color_t color);
+/**
+ * Draws the sequence with word-wrap inside @p box_width.
+ * @p height_offset overrides the per-line advance; pass 0 to use the font default.
+ * Returns the total pixel height used.
+ */
 int lang_text_draw_sequence_multiline(const lang_fragment *seq, int count, int x, int y, int box_width, int height_offset, font_t font, color_t color);
+/** Draws the sequence horizontally centred within @p box_width. Returns the width drawn. */
 int lang_text_draw_sequence_centered(const lang_fragment *seq, int count, int x, int y, int box_width, font_t font, color_t color);
+/**
+ * Draws the sequence, truncating with an ellipsis if it exceeds @p box_width.
+ * Sets @p *was_ellipsized (may be NULL) to 1 if truncation occurred.
+ * Returns the width drawn.
+ */
 int lang_text_draw_sequence_ellipsized(const lang_fragment *seq, int count, int x, int y, int box_width,
     font_t font, color_t color, int *was_ellipsized);
-
+/**
+ * Centred variant of @ref lang_text_draw_sequence_ellipsized.
+ * Centres the sequence when it fits; falls back to left-aligned with ellipsis when it does not.
+ */
 int lang_text_draw_sequence_centered_ellipsized(const lang_fragment *seq, int count, int x, int y, int box_width, font_t font, color_t color, int *was_ellipsized);
-
+/**
+ * Concatenates the text content of the sequence into @p dst (size @p dst_size), null-terminated.
+ * Returns the number of bytes written, excluding the null terminator.
+ */
 int lang_text_concatenate_sequence(const lang_fragment *seq, int count, uint8_t *dst, int dst_size);
+/** @} */
 
 #endif // GRAPHICS_LANG_TEXT_H

--- a/src/graphics/text.c
+++ b/src/graphics/text.c
@@ -153,6 +153,29 @@ int text_get_number_width(int value, char prefix, const char *postfix, font_t fo
     return width;
 }
 
+int text_get_number_float_width(float value, int decimal_places, char prefix, const char *postfix, font_t font)
+{
+    const font_definition *def = font_definition_for(font);
+
+    int width = 0;
+
+    if (prefix) {
+        uint8_t prefix_str[2] = { prefix, 0 };
+        width += text_get_width(prefix_str, font);
+    }
+
+    uint8_t buffer[NUMBER_BUFFER_LENGTH];
+    string_from_float(buffer, value, decimal_places, 0);
+    width += text_get_width(buffer, font);
+
+    if (postfix && *postfix) {
+        width += text_get_width(string_from_ascii(postfix), font);
+    } else {
+        width += def->space_width;
+    }
+    return width;
+}
+
 static int get_letter_width(const uint8_t *str, const font_definition *def, int *num_bytes)
 {
     *num_bytes = 1;
@@ -397,6 +420,21 @@ static int number_to_string(uint8_t *str, int value, char prefix, const char *po
     return offset;
 }
 
+static int number_float_to_string(uint8_t *str, float value, int decimal_places, char prefix, const char *postfix)
+{
+    int offset = 0;
+    if (prefix) {
+        str[offset++] = prefix;
+    }
+    offset += string_from_float(&str[offset], value, decimal_places, 0);
+    while (*postfix) {
+        str[offset++] = *postfix;
+        postfix++;
+    }
+    str[offset] = 0;
+    return offset;
+}
+
 int text_draw_number_scaled(int value, char prefix, const uint8_t *postfix,
     int x, int y, font_t font, color_t color, float scale)
 {
@@ -450,6 +488,53 @@ int text_draw_number(int value, char prefix, const char *postfix, int x, int y, 
     const uint8_t *ascii_postfix = postfix && *postfix ? string_from_ascii(postfix) : 0;
     return text_draw_number_scaled(value, prefix, ascii_postfix, x, y, font, color, SCALE_NONE);
 }
+
+int text_draw_number_float_scaled(float value, int decimal_places, char prefix, const uint8_t *postfix,
+    int x, int y, font_t font, color_t color, float scale)
+{
+    uint8_t str[NUMBER_BUFFER_LENGTH];
+    number_float_to_string(str, value, decimal_places, prefix, postfix ? (const char *) postfix : "");
+    return text_draw_scaled(str, x, y, font, color, scale);
+}
+
+int text_draw_number_float(float value, int decimal_places, char prefix, const char *postfix,
+    int x, int y, font_t font, color_t color)
+{
+    const uint8_t *ascii_postfix = postfix && *postfix ? string_from_ascii(postfix) : 0;
+    return text_draw_number_float_scaled(value, decimal_places, prefix, ascii_postfix, x, y, font, color, SCALE_NONE);
+}
+
+void text_draw_number_float_centered(float value, int decimal_places, int x_offset, int y_offset, int box_width, font_t font)
+{
+    uint8_t str[NUMBER_BUFFER_LENGTH];
+    number_float_to_string(str, value, decimal_places, 0, "");
+    text_draw_centered(str, x_offset, y_offset, box_width, font, 0);
+}
+
+void text_draw_number_float_centered_prefix(
+    float value, int decimal_places, char prefix, int x_offset, int y_offset, int box_width, font_t font)
+{
+    uint8_t str[NUMBER_BUFFER_LENGTH];
+    number_float_to_string(str, value, decimal_places, prefix, "");
+    text_draw_centered(str, x_offset, y_offset, box_width, font, 0);
+}
+
+void text_draw_number_float_centered_postfix(
+    float value, int decimal_places, const char *postfix, int x_offset, int y_offset, int box_width, font_t font)
+{
+    uint8_t str[NUMBER_BUFFER_LENGTH];
+    number_float_to_string(str, value, decimal_places, 0, postfix ? postfix : "");
+    text_draw_centered(str, x_offset, y_offset, box_width, font, 0);
+}
+
+void text_draw_number_float_centered_colored(
+    float value, int decimal_places, int x_offset, int y_offset, int box_width, font_t font, color_t color)
+{
+    uint8_t str[NUMBER_BUFFER_LENGTH];
+    number_float_to_string(str, value, decimal_places, 0, "");
+    text_draw_centered(str, x_offset, y_offset, box_width, font, color);
+}
+
 
 void text_draw_number_finances(int value, int x, int y, font_t font, color_t color)
 {

--- a/src/graphics/text.h
+++ b/src/graphics/text.h
@@ -12,6 +12,7 @@ void text_draw_cursor(int x_offset, int y_offset, int is_insert);
 
 int text_get_width(const uint8_t *str, font_t font);
 int text_get_number_width(int value, char prefix, const char *postfix, font_t font);
+int text_get_number_float_width(float value, int decimal_places, char prefix, const char *postfix, font_t font);
 unsigned int text_get_max_length_for_width(
     const uint8_t *str, int length, font_t font, unsigned int requested_width, int invert);
 void text_ellipsize(uint8_t *str, font_t font, int requested_width);
@@ -29,6 +30,10 @@ int text_draw_number(int value, char prefix, const char *postfix, int x, int y, 
 void text_draw_number_finances(int value, int x, int y, font_t font, color_t color);
 int text_draw_number_scaled(int value, char prefix, const uint8_t *postfix,
         int x, int y, font_t font, color_t color, float scale);
+int text_draw_number_float(float value, int decimal_places, char prefix, const char *postfix,
+    int x, int y, font_t font, color_t color);
+int text_draw_number_float_scaled(float value, int decimal_places, char prefix, const uint8_t *postfix,
+    int x, int y, font_t font, color_t color, float scale);
 int text_draw_money(int value, int x_offset, int y_offset, font_t font);
 void text_draw_with_money(const uint8_t *text, int value, const char *prefix, const char *postfix,
     int x_offset, int y_offset, int box_width, font_t font, color_t color);
@@ -47,6 +52,13 @@ void text_draw_number_centered_postfix(
     int value, const char *postfix, int x_offset, int y_offset, int box_width, font_t font);
 void text_draw_number_centered_colored(
     int value, int x_offset, int y_offset, int box_width, font_t font, color_t color);
+void text_draw_number_float_centered(float value, int decimal_places, int x_offset, int y_offset, int box_width, font_t font);
+void text_draw_number_float_centered_prefix(
+    float value, int decimal_places, char prefix, int x_offset, int y_offset, int box_width, font_t font);
+void text_draw_number_float_centered_postfix(
+    float value, int decimal_places, const char *postfix, int x_offset, int y_offset, int box_width, font_t font);
+void text_draw_number_float_centered_colored(
+    float value, int decimal_places, int x_offset, int y_offset, int box_width, font_t font, color_t color);
 
 int text_draw_multiline(const uint8_t *str, int x_offset, int y_offset, int box_width,
     int centered, font_t font, color_t color);


### PR DESCRIPTION
@Johannes-callidus let me know any feedback for these:
* Added string_from_float
* Added text_draw_number_float with standard variants

for `lang_fragment`:
* Added public constructor functions to ease users into working with fragments
* Updated doxygen comments
* Integrated `FRAGMENT_TYPE_FLOAT`