### PR TITLE
Show Fountains and Wells on Global Health and Sickness overlays

### DIFF
--- a/src/widget/city/overlay/health.c
+++ b/src/widget/city/overlay/health.c
@@ -10,6 +10,7 @@ static int show_building_health(const building *b)
     return b->type == BUILDING_HOSPITAL || b->type == BUILDING_DOCTOR ||
            b->type == BUILDING_BARBER || b->type == BUILDING_BATHHOUSE ||
            b->type == BUILDING_SMALL_MAUSOLEUM || b->type == BUILDING_LARGE_MAUSOLEUM ||
+           b->type == BUILDING_FOUNTAIN || b->type == BUILDING_WELL ||
            b->type == BUILDING_LATRINES;
 }
 
@@ -38,6 +39,7 @@ static int show_building_sickness(const building *b)
     return b->type == BUILDING_HOSPITAL || b->type == BUILDING_DOCTOR ||
            b->type == BUILDING_BARBER || b->type == BUILDING_BATHHOUSE ||
            b->type == BUILDING_SMALL_MAUSOLEUM || b->type == BUILDING_LARGE_MAUSOLEUM ||
+           b->type == BUILDING_FOUNTAIN || b->type == BUILDING_WELL ||
            b->type == BUILDING_LATRINES;
 }
 


### PR DESCRIPTION
As Fountains and Wells+Latrines now give health points and help fighting sickness. (and fountains and wells are kind of hidden now on the Water overlay due to houses being drawn)