### PR TITLE
 Fix meadow tiles disappearing when earthquake starts

### DIFF
--- a/src/scenario/earthquake.c
+++ b/src/scenario/earthquake.c
@@ -123,10 +123,12 @@ static void advance_earthquake_to_tile(int x, int y)
     map_tiles_clear_highway(grid_offset, 0);
     map_terrain_set(grid_offset, 0);
     map_tiles_set_earthquake(x, y);
+    map_tiles_update_all_empty_land();
     map_tiles_update_all_gardens();
     map_tiles_update_all_roads();
     map_tiles_update_all_highways();
     map_tiles_update_all_plazas();
+    map_tiles_update_all_meadow();
     map_tiles_update_all_walls();
     map_tiles_update_all_aqueducts(0);
 

--- a/src/scenario/earthquake.c
+++ b/src/scenario/earthquake.c
@@ -123,11 +123,12 @@ static void advance_earthquake_to_tile(int x, int y)
     map_tiles_clear_highway(grid_offset, 0);
     map_terrain_set(grid_offset, 0);
     map_tiles_set_earthquake(x, y);
-    map_tiles_update_all_empty_land();
     map_tiles_update_all_gardens();
     map_tiles_update_all_roads();
     map_tiles_update_all_highways();
     map_tiles_update_all_plazas();
+    map_tiles_update_all_walls();
+    map_tiles_update_all_aqueducts(0);
 
     map_routing_update_land();
     map_routing_update_walls();


### PR DESCRIPTION
- Prevent meadow tiles disappearing when earthquake starts
fix bug https://discord.com/channels/136544899339124736/1518915494198120518

- Update walls and aqueducts over highways when damaged by earthquake
When sections of highways under aqueducts were destroyed, black tiles appeared.


[savegames.zip](https://github.com/user-attachments/files/29252840/savegames.zip)
