### PR TITLE
Fix MSVC builds

### DIFF
--- a/.ci_scripts/run_build.ps1
+++ b/.ci_scripts/run_build.ps1
@@ -9,7 +9,7 @@ if ($SDL_MAJOR_VERSION -eq "3") {
 }
 
 if ("${env:COMPILER}" -eq "msvc") {
-    cmake -G "Visual Studio 17 2022" -A x64 -DAV1_VIDEO_SUPPORT=ON $CMAKE_SDL_VERSION "$CMAKE_SDL_PREFIX" -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+    cmake -G "Visual Studio 18 2026" -A x64 -DAV1_VIDEO_SUPPORT=ON $CMAKE_SDL_VERSION "$CMAKE_SDL_PREFIX" -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
     cmake --build . -j 4 --config RelWithDebInfo
 } elseif ("${env:COMPILER}" -eq "msvc-arm64") {
     cmake -G "Ninja" -DAV1_VIDEO_SUPPORT=ON $CMAKE_SDL_VERSION "$CMAKE_SDL_PREFIX" -DCMAKE_BUILD_TYPE=RelWithDebInfo ..

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,12 +171,12 @@ jobs:
             SDL_VERSION: 3.4.8
             SDL_MIXER_VERSION: 3.2.2
             SKIP_UPLOAD: true
-           - name: Windows MSVC x64
-             cache-key: msvc
-             COMPILER: msvc
-             SDL_VERSION: 2.32.10
-             SDL_MIXER_VERSION: 2.8.2
-             SKIP_UPLOAD: true
+          - name: Windows MSVC x64
+            cache-key: msvc
+            COMPILER: msvc
+            SDL_VERSION: 2.32.10
+            SDL_MIXER_VERSION: 2.8.2
+            SKIP_UPLOAD: true
           - name: Windows MSVC ARM64
             cache-key: msvc-arm64
             COMPILER: msvc-arm64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,12 +171,12 @@ jobs:
             SDL_VERSION: 3.4.8
             SDL_MIXER_VERSION: 3.2.2
             SKIP_UPLOAD: true
-          # - name: Windows MSVC x64
-          #   cache-key: msvc
-          #   COMPILER: msvc
-          #   SDL_VERSION: 2.32.10
-          #   SDL_MIXER_VERSION: 2.8.2
-          #   SKIP_UPLOAD: true
+           - name: Windows MSVC x64
+             cache-key: msvc
+             COMPILER: msvc
+             SDL_VERSION: 2.32.10
+             SDL_MIXER_VERSION: 2.8.2
+             SKIP_UPLOAD: true
           - name: Windows MSVC ARM64
             cache-key: msvc-arm64
             COMPILER: msvc-arm64


### PR DESCRIPTION
As mentioned before MSVC builds were failing on regular basis due to github dropping support for older Visual Studio versions. And since bianka also updated I thought we should do it as well.