### PR TITLE
Fix trade ships leaving through unreachable river exit blocked by low bridges

### DIFF
--- a/src/figuretype/trader.c
+++ b/src/figuretype/trader.c
@@ -954,6 +954,13 @@ void figure_trade_ship_action(figure *f)
                         int entrance_grid_offset = map_grid_offset(river_entry.x, river_entry.y);
                         int entrance_distance = map_grid_chess_distance(f->grid_offset, entrance_grid_offset);
                         river_spot = exit_distance < entrance_distance ? river_exit : river_entry;
+
+                        // Fix unreachable river exit for trade ships (low bridge)
+                        map_routing_calculate_distances_water_boat(f->x, f->y);
+                        if (map_routing_distance(map_grid_offset(river_spot.x, river_spot.y)) == 0) {
+                            river_spot = (river_spot.x == river_exit.x && river_spot.y == river_exit.y)
+                                ? river_entry : river_exit;
+                        }
                     } else {
                         river_spot = river_entry;
                     }

--- a/src/scenario/map.c
+++ b/src/scenario/map.c
@@ -1,5 +1,7 @@
 #include "map.h"
 
+#include "map/routing.h"
+
 #include "core/calc.h"
 #include "map/grid.h"
 #include "scenario/data.h"
@@ -90,19 +92,24 @@ int scenario_map_closest_fishing_point(int x, int y, map_point *fish)
     if (num_fishing_spots <= 0) {
         return 0;
     }
+    map_routing_calculate_distances_water_boat(x, y);
     int min_dist = 10000;
-    int min_fish_id = 0;
+    int min_fish_id = -1;
     for (int i = 0; i < MAX_FISH_POINTS; i++) {
-        if (scenario.fishing_points[i].x > 0) {
-            int dist = calc_maximum_distance(x, y,
-                scenario.fishing_points[i].x, scenario.fishing_points[i].y);
-            if (dist < min_dist) {
-                min_dist = dist;
-                min_fish_id = i;
-            }
+        if (scenario.fishing_points[i].x <= 0) {
+            continue;
+        }
+        int offset = map_grid_offset(scenario.fishing_points[i].x, scenario.fishing_points[i].y);
+        int dist = map_routing_distance(offset);
+        if (dist <= 0) {
+            continue;
+        }
+        if (dist < min_dist) {
+            min_dist = dist;
+            min_fish_id = i;
         }
     }
-    if (min_dist < 10000) {
+    if (min_fish_id >= 0) {
         map_point_store_result(
             scenario.fishing_points[min_fish_id].x,
             scenario.fishing_points[min_fish_id].y,


### PR DESCRIPTION
**-** [Fix] trade ships leaving through unreachable river exit blocked by low bridges
[test-dock EXIT.zip](https://github.com/user-attachments/files/30065646/test-dock.EXIT.zip)

**-** [FIX] Fishing boats choosing another fishing spot if the nearest becomes unreachable
Previously, the boats would stay idle and wait for the nearest fishing spot to unlock.
[test-fising.zip](https://github.com/user-attachments/files/30067405/test-fising.zip)
