### PR TITLE
Improve gold and bronze shield display for goods

### DIFF
--- a/src/window/empire.c
+++ b/src/window/empire.c
@@ -1487,9 +1487,17 @@ static void draw_trade_resource(resource_type r, int trade_max, int x, int y)
 
 void window_empire_draw_resource_shields(int trade_max, int x_offset, int y_offset)
 {
-    int num_bronze_shields = (trade_max % 100) / 20 + 1;
-    if (trade_max >= 600) {
+    int num_gold_shields = trade_max / 100;
+    int remainder = (trade_max % 100);
+    int num_bronze_shields = (remainder + 10) / 20;
+
+    if (num_bronze_shields > 5) {
         num_bronze_shields = 5;
+    }
+
+    if (num_gold_shields > 7) {
+        num_gold_shields = 7;
+        num_bronze_shields = 0;
     }
 
     int top_left_x;
@@ -1507,10 +1515,6 @@ void window_empire_draw_resource_shields(int trade_max, int x_offset, int y_offs
         image_draw(bronze_shield, top_left_x + pt.x, top_left_y + pt.y, COLOR_MASK_NONE, SCALE_NONE);
     }
 
-    int num_gold_shields = trade_max / 100;
-    if (num_gold_shields > 5) {
-        num_gold_shields = 5;
-    }
     top_left_x = x_offset - 1;
     top_left_y = y_offset + 22;
     int gold_shield = assets_lookup_image_id(ASSET_GOLD_SHIELD);


### PR DESCRIPTION
The Empire Map depicts the relative quantities of goods for import/export by displaying gold shields below each resource's icon and bronze shields above the icon. Until now, the calculations for how many of each shield type to display were entirely independent of each other. 

This change gives a more rational depiction so that the relative quantities of each good can be quickly assessed to highlight the major goods that can be traded when compared to the others, and so that the number of shields can be understood by all.

As before, each gold shield represents 100 carts and each bronze shield represents 20 carts, rounded up to the nearest 20 carts.
However, the shields now show a far more accurate depiction of the quantities.

<img width="528" height="551" alt="2026-08-11_231632 shields" src="https://github.com/user-attachments/assets/76be4378-8815-4faf-95ca-13876ef4d5b2" />

E.g.
1. The quotas for Corinthus vegetables and Lydia wheat now exceed the maximum number of gold shields (seven), so each good's icon will be neatly underlined with gold shields so they stand out as exceptional tradable goods.
2. Rhodes iron and sand accurately depict the 140 carts as one gold shield (100) and two bronze shields (40).
3. The 200 carts of Lydia iron are accurately depicted as exactly two gold shields.
4. The lower-quantity traders such as Athenae have all their lower quotas represented by only bronze shields, rounded up to the nearest 20.
5. Rhodes pottery and bricks (both 40 carts) each get two bronze shields.
6. The 18 carts of Rhodes oil and wine both round up to one bronze shield each.

The relative quota sizes are represented as before but the number of shields now accurately reflects the actual number of carts reported by the numeric digits.