### PR TITLE
editor: Demand change window redesigned

### DIFF
--- a/src/window/editor/demand_changes.c
+++ b/src/window/editor/demand_changes.c
@@ -98,9 +98,6 @@ static void update_demand_changes_list(void)
             }
         }
         data.total_demand_changes = current_demand_changes;
-        limit_and_sort_list();
-        grid_box_update_total_items(&demand_change_buttons, data.demand_changes_in_use);
-        return;
     }
     limit_and_sort_list();
     if (grid_box_get_total_items(&demand_change_buttons) != data.demand_changes_in_use) {
@@ -193,21 +190,21 @@ static void draw_demand_change_button(const grid_box_item *item)
     int COL_BUY_SELL = 280;
     int COL_CITY = 380;
 
-    // 1
+    // 1 year
     text_draw_number(demand_change->year, '+', " ", item->x + COL_YEAR, item->y + 7, FONT_NORMAL_BLACK, 0);
 
-    // 2
+    // 2 scenario start year
     lang_text_draw_year(scenario_property_start_year() + demand_change->year, item->x + COL_SCENARIO, item->y + 7,
         FONT_NORMAL_BLACK);
 
-    // 3
+    // 3 resource icon
     int image_id = resource_get_data(demand_change->resource)->image.editor.icon;
     const image *img = image_get(image_id);
     int base_width = (24 - img->original.width) / 2;
     int base_height = (item->height - img->original.height) / 2;
     image_draw(image_id, item->x + COL_RESOURCE + base_width, item->y + base_height, COLOR_MASK_NONE, SCALE_NONE);
 
-    // 4
+    // 4 amount
     demand_change_amount_t amount;
     get_change_amount(item->index, &amount);
     int width = 0;

--- a/src/window/editor/demand_changes.c
+++ b/src/window/editor/demand_changes.c
@@ -189,7 +189,7 @@ static void draw_demand_change_button(const grid_box_item *item)
     int COL_YEAR = 5;
     int COL_SCENARIO = 45;
     int COL_RESOURCE = 140;
-    int COL_AMOUNT = 170;
+    int COL_AMOUNT = 165;
     int COL_BUY_SELL = 280;
     int COL_CITY = 380;
 

--- a/src/window/editor/demand_changes.c
+++ b/src/window/editor/demand_changes.c
@@ -2,6 +2,7 @@
 
 #include "core/image_group_editor.h"
 #include "core/string.h"
+#include "empire/city.h"
 #include "empire/trade_route.h"
 #include "game/resource.h"
 #include "graphics/button.h"
@@ -48,10 +49,10 @@ static grid_box_type demand_change_buttons = {
     .y = 40,
     .width = 38 * BLOCK_SIZE,
     .height = 19 * BLOCK_SIZE,
-    .num_columns = 2,
-    .item_height = 30,
+    .num_columns = 1,
+    .item_height = 28,
     .item_margin.horizontal = 10,
-    .item_margin.vertical = 5,
+    .item_margin.vertical = 4,
     .extend_to_hidden_scrollbar = 1,
     .on_click = button_demand_change,
     .draw_item = draw_demand_change_button
@@ -97,9 +98,14 @@ static void update_demand_changes_list(void)
             }
         }
         data.total_demand_changes = current_demand_changes;
+        limit_and_sort_list();
+        grid_box_update_total_items(&demand_change_buttons, data.demand_changes_in_use);
+        return;
     }
     limit_and_sort_list();
-    grid_box_update_total_items(&demand_change_buttons, data.demand_changes_in_use);
+    if (grid_box_get_total_items(&demand_change_buttons) != data.demand_changes_in_use) {
+        grid_box_update_total_items(&demand_change_buttons, data.demand_changes_in_use);
+    }
 }
 
 static void draw_background(void)
@@ -111,7 +117,7 @@ static void draw_background(void)
     graphics_in_dialog();
 
     outer_panel_draw(0, 0, 40, 25);
-    lang_text_draw(44, 94, 20, 14, FONT_LARGE_BLACK);
+    lang_text_draw(44, 94, 20, 12, FONT_LARGE_BLACK);
 
     if (!data.demand_changes_in_use) {
         lang_text_draw_centered(CUSTOM_TRANSLATION, TR_EDITOR_NO_DEMAND_CHANGES, 0, 165, 640, FONT_LARGE_BLACK);
@@ -162,33 +168,71 @@ static void get_change_amount(unsigned int index, demand_change_amount_t *amount
     amount->difference = amount->value - previous_value;
 }
 
+static const uint8_t *get_route_name(int route_id)
+{
+    int city_id = empire_city_get_for_trade_route(route_id);
+    if (city_id < 0) {
+        return lang_get_string(CUSTOM_TRANSLATION, TR_EDITOR_UNKNOWN_ROUTE);
+    }
+    empire_city *city = empire_city_get(city_id);
+    if (city->type == EMPIRE_CITY_TRADE || city->type == EMPIRE_CITY_FUTURE_TRADE) {
+        return empire_city_get_name(city);
+    }
+    return lang_get_string(CUSTOM_TRANSLATION, TR_EDITOR_UNKNOWN_ROUTE);
+}
+
 static void draw_demand_change_button(const grid_box_item *item)
 {
     button_border_draw(item->x, item->y, item->width, item->height, item->is_focused);
     const demand_change_t *demand_change = data.demand_changes[item->index];
-    text_draw_number(demand_change->year, '+', " ", item->x + 5, item->y + 7, FONT_NORMAL_BLACK, 0);
-    int width = lang_text_draw_year(scenario_property_start_year() + demand_change->year, item->x + 40, item->y + 7,
+
+    int COL_YEAR = 5;
+    int COL_SCENARIO = 45;
+    int COL_RESOURCE = 140;
+    int COL_AMOUNT = 170;
+    int COL_BUY_SELL = 280;
+    int COL_CITY = 380;
+
+    // 1
+    text_draw_number(demand_change->year, '+', " ", item->x + COL_YEAR, item->y + 7, FONT_NORMAL_BLACK, 0);
+
+    // 2
+    lang_text_draw_year(scenario_property_start_year() + demand_change->year, item->x + COL_SCENARIO, item->y + 7,
         FONT_NORMAL_BLACK);
+
+    // 3
     int image_id = resource_get_data(demand_change->resource)->image.editor.icon;
     const image *img = image_get(image_id);
+    int base_width = (24 - img->original.width) / 2;
     int base_height = (item->height - img->original.height) / 2;
-    image_draw(image_id, item->x + 45 + width, item->y + base_height, COLOR_MASK_NONE, SCALE_NONE);
-    width += lang_text_draw(CUSTOM_TRANSLATION, TR_EDITOR_SHORT_ROUTE_TEXT, item->x + 75 + width, item->y + 7,
-        FONT_NORMAL_BLACK);
-    width += text_draw_number(demand_change->route_id, '@', " ", item->x + 75 + width, item->y + 7,
-        FONT_NORMAL_BLACK, 0);
+    image_draw(image_id, item->x + COL_RESOURCE + base_width, item->y + base_height, COLOR_MASK_NONE, SCALE_NONE);
+
+    // 4
     demand_change_amount_t amount;
     get_change_amount(item->index, &amount);
-    width += text_draw_number(amount.value, '@', " ", item->x + 75 + width, item->y + 7, FONT_NORMAL_BLACK, 0);
+    int width = 0;
+    int x_amount = item->x + COL_AMOUNT;
+    width += text_draw_number(amount.value, '@', " ", x_amount + width, item->y + 7,
+        FONT_NORMAL_BLACK, 0);
     if (amount.difference > 0) {
-        width += text_draw(string_from_ascii("("), item->x + 70 + width, item->y + 7,
-            FONT_NORMAL_PLAIN, COLOR_MASK_DARK_GREEN);
-        width += text_draw_number(amount.difference, '+', ")", item->x + 70 + width - 5, item->y + 7,
-            FONT_NORMAL_PLAIN, COLOR_MASK_DARK_GREEN);
+        width += text_draw(string_from_ascii("("), x_amount + width - 8, item->y + 7,
+            FONT_NORMAL_PLAIN, COLOR_FONT_DARK_GREEN);
+        width += text_draw_number(amount.difference, '+', ")", x_amount + width - 13, item->y + 7,
+            FONT_NORMAL_PLAIN, COLOR_FONT_DARK_GREEN);
     } else {
-        width += text_draw_number(amount.difference, '(', ")", item->x + 70 + width, item->y + 7,
-            FONT_NORMAL_PLAIN, COLOR_MASK_PURPLE);
+        width += text_draw_number(amount.difference, '(', ")", x_amount + width - 8, item->y + 7,
+            FONT_NORMAL_PLAIN, COLOR_FONT_RED);
     }
+
+    // 5 buys-sells
+    translation_key key = demand_change->buys ? TR_EDITOR_DEMAND_CHANGE_BUYS : TR_EDITOR_DEMAND_CHANGE_SELLS;
+    int color = demand_change->buys ? COLOR_MASK_DARK_GREEN : COLOR_MASK_PURPLE;
+    lang_text_draw_colored(CUSTOM_TRANSLATION, key, item->x + COL_BUY_SELL, item->y + 7,
+        FONT_NORMAL_PLAIN, color);
+
+    // 6 city name
+    text_draw(get_route_name(demand_change->route_id), item->x + COL_CITY, item->y + 7,
+        FONT_NORMAL_BLACK, COLOR_MASK_NONE);
 }
 
 static void draw_foreground(void)

--- a/src/window/editor/invasions.c
+++ b/src/window/editor/invasions.c
@@ -82,8 +82,8 @@ static void limit_and_sort_list(void)
 
 static void update_invasion_list(void)
 {
-    int current_invasions = scenario_invasion_count_total();
-    if ((unsigned int) current_invasions != data.total_invasions) {
+    unsigned int current_invasions = scenario_invasion_count_total();
+    if (current_invasions != data.total_invasions) {
         free(data.invasions);
         data.invasions = 0;
         if (current_invasions) {
@@ -98,7 +98,9 @@ static void update_invasion_list(void)
         data.total_invasions = current_invasions;
     }
     limit_and_sort_list();
-    grid_box_update_total_items(&invasion_buttons, data.invasions_in_use);
+    if (grid_box_get_total_items(&invasion_buttons) != data.invasions_in_use) {
+        grid_box_update_total_items(&invasion_buttons, data.invasions_in_use);
+    }
 }
 
 static void draw_background(void)

--- a/src/window/editor/price_changes.c
+++ b/src/window/editor/price_changes.c
@@ -38,9 +38,9 @@ static grid_box_type price_change_buttons = {
     .width = 38 * BLOCK_SIZE,
     .height = 19 * BLOCK_SIZE,
     .num_columns = 2,
-    .item_height = 30,
+    .item_height = 28,
     .item_margin.horizontal = 10,
-    .item_margin.vertical = 5,
+    .item_margin.vertical = 4,
     .extend_to_hidden_scrollbar = 1,
     .on_click = button_price_change,
     .draw_item = draw_price_change_button
@@ -92,7 +92,9 @@ static void update_price_changes_list(void)
         data.total_price_changes = current_price_changes;
     }
     limit_and_sort_list();
-    grid_box_update_total_items(&price_change_buttons, data.price_changes_in_use);
+    if (grid_box_get_total_items(&price_change_buttons) != data.price_changes_in_use) {
+        grid_box_update_total_items(&price_change_buttons, data.price_changes_in_use);
+    }
 }
 
 static void draw_background(void)

--- a/src/window/editor/requests.c
+++ b/src/window/editor/requests.c
@@ -91,9 +91,14 @@ static void update_request_list(void)
             }
         }
         data.total_requests = current_requests;
+        limit_and_sort_list();
+        grid_box_update_total_items(&request_buttons, data.requests_in_use);
+        return;
     }
     limit_and_sort_list();
-    grid_box_update_total_items(&request_buttons, data.requests_in_use);
+    if (grid_box_get_total_items(&request_buttons) != data.requests_in_use) {
+        grid_box_update_total_items(&request_buttons, data.requests_in_use);
+    }
 }
 
 static void draw_background(void)

--- a/src/window/editor/requests.c
+++ b/src/window/editor/requests.c
@@ -91,9 +91,6 @@ static void update_request_list(void)
             }
         }
         data.total_requests = current_requests;
-        limit_and_sort_list();
-        grid_box_update_total_items(&request_buttons, data.requests_in_use);
-        return;
     }
     limit_and_sort_list();
     if (grid_box_get_total_items(&request_buttons) != data.requests_in_use) {


### PR DESCRIPTION
1.  The red border was missing when the element was focused.
2.  The demand change window has been redesigned. It now displays the city name and whether it’s a buy or sell.


<details>

before
<img width="687" height="448" alt="2026-08-15_133117" src="https://github.com/user-attachments/assets/d8e650b8-a16c-4957-ab0b-0db521f5379e" />

after

<img width="679" height="445" alt="2026-08-15_132718" src="https://github.com/user-attachments/assets/b05f01f1-c22e-4f32-86f5-bd0a48268114" />
<img width="701" height="461" alt="2026-08-15_132814" src="https://github.com/user-attachments/assets/0d3eb0ee-3437-48e2-9bf5-40cebc7ba96b" />
<img width="691" height="450" alt="2026-08-15_132916" src="https://github.com/user-attachments/assets/bf2000e5-f62c-4843-83db-88d2172beb83" />
<img width="691" height="451" alt="2026-08-15_133001" src="https://github.com/user-attachments/assets/38d81aba-c0b3-4106-970f-bc7021cbbc1b" />

<img width="681" height="442" alt="2026-08-15_135418" src="https://github.com/user-attachments/assets/a5f2533e-0fec-47f4-8032-f48014708118" />




</details> 