### PR TITLE
Fix black tile appearing after loading a saved game

### DIFF
--- a/src/map/image.c
+++ b/src/map/image.c
@@ -77,7 +77,7 @@ void map_image_update_all(void)
                 calc_percentage(b->data.industry.progress, building_industry_get_max_progress(b)));
             continue;
         }
-        if (b->type == BUILDING_SHIP_BRIDGE || b->type == BUILDING_LOW_BRIDGE || b->type == BUILDING_WALL) {
+        if (b->type == BUILDING_SHIP_BRIDGE || b->type == BUILDING_LOW_BRIDGE || b->type == BUILDING_WALL || b->type == BUILDING_AQUEDUCT) {
             continue; //bridges are drawn as a part of terrain drawing, and their image shouldnt be fetched.
         }
         int image_id = building_image_get(b);

--- a/src/map/image.c
+++ b/src/map/image.c
@@ -2,6 +2,7 @@
 
 #include "building/image.h"
 #include "building/industry.h"
+#include "building/properties.h"
 #include "core/calc.h"
 #include "core/image.h"
 #include "core/image_group.h"
@@ -77,8 +78,8 @@ void map_image_update_all(void)
                 calc_percentage(b->data.industry.progress, building_industry_get_max_progress(b)));
             continue;
         }
-        if (b->type == BUILDING_SHIP_BRIDGE || b->type == BUILDING_LOW_BRIDGE || b->type == BUILDING_WALL || b->type == BUILDING_AQUEDUCT) {
-            continue; //bridges are drawn as a part of terrain drawing, and their image shouldnt be fetched.
+        if (b->type == BUILDING_SHIP_BRIDGE || b->type == BUILDING_LOW_BRIDGE || building_properties_for_type(b->type)->shared) {
+            continue; //bridges are drawn as a part of terrain drawing, and their image shouldnt be fetched. Fetching shared building image will cause a black tile(0,0) to appear on the map.
         }
         int image_id = building_image_get(b);
 


### PR DESCRIPTION
Fixed the bug of issue  #1780.

The common shared building data structure for walls and aqueducts saved in a save file caused the black tile to appear right after the file was loaded.  

Added aqueducts to the list of not fetching images(walls was already there).

Edit: Changed code for future shared buildings.