### PR TITLE
Fix off-by-one storage selection in Cart Depot source/destination list

### DIFF
--- a/src/window/building/depot.c
+++ b/src/window/building/depot.c
@@ -179,6 +179,7 @@ static void setup_buttons_for_selected_depot(void)
         const data_storage *storage = building_storage_get_array_entry(i);
         building *store_building = building_get(storage->building_id);
         if (!storage->in_use || !storage->building_id || store_building->state == BUILDING_STATE_MOTHBALLED ||
+             store_building->state == BUILDING_STATE_RUBBLE ||
              (!resource_is_food(data.target_resource_id) && store_building->type == BUILDING_GRANARY)) {
             continue;
         }


### PR DESCRIPTION
Fixes #1624

## Problem

When selecting a source or destination storage building for a Cart Depot, the building actually assigned to the order didn't match the one the player clicked — e.g. selecting "Granary 16" in the list would set the order's source to Granary 15 instead. Because the wrong building sometimes didn't accept the target resource, this also produced a UI glitch where the Source button showed both "Select source" and "Granary 15" at once.

## Root cause

The storage list on the select-source/destination screen is built by two separate loops that each recompute their own row layout over building_storage_get_array_entry():

- setup_buttons_for_selected_depot() — assigns each row's clickable building_id (what a click resolves to)
- window_building_draw_depot_select_source_destination() — decides what's actually drawn at each row position

These two loops must stay in lockstep for row N to mean the same building in both places, but their filtering conditions differ: setup_buttons_for_selected_depot()'s first pass doesn't exclude buildings in BUILDING_STATE_RUBBLE, while the draw function's first pass does. Whenever a rubble storage building exists earlier in the list, the two loops diverge by one row, and every subsequent row's visible label and click target point at different buildings.

## Fix

Add the same BUILDING_STATE_RUBBLE exclusion to setup_buttons_for_selected_depot()'s first pass, so both functions filter identically.

## Testing

Reproduced the issue using the save file attached to #1624 (selecting Granary 16 previously selected Granary 15). After this fix, selecting a storage building in the list correctly assigns that same building to the order, and the "Select source"/"Granary X" double-text glitch no longer occurs.

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/e2a735d9-c959-47c6-b681-b1b2c540f211" ></video> | <video src="https://github.com/user-attachments/assets/64d86088-f31f-48f1-a30e-a492f0d21ff8" ></video> |

## Notes for reviewers

This is a minimal, targeted fix for the specific reported case. There's a second, structurally similar divergence between these same two functions in their "secondary/inactive storages" pass (differing treatment of storage->in_use), which I ~haven't addressed here~ since I don't have a save file that reproduces it. Longer-term, the real fix is probably to have the draw function reuse the row list computed by setup_buttons_for_selected_depot() instead of recalculating it independently, which would eliminate this whole class of bug — happy to follow up with that refactor in a separate PR if preferred. Opened this as a standalone minimal fix in the meantime since it resolves the reported issue.
